### PR TITLE
UI: #21 ProjectLayout의 Sidebar를 공용 Sidebar로 추출

### DIFF
--- a/src/components/sidebar/ListProject.tsx
+++ b/src/components/sidebar/ListProject.tsx
@@ -1,8 +1,8 @@
 import { Link, useParams } from 'react-router-dom';
-import type { ProjectType } from '@/types/project';
+import type { Project } from '@/types/ProjectType';
 
 type ListProjectProps = {
-  data: ProjectType[];
+  data: Project[];
   targetId?: string;
 };
 

--- a/src/components/sidebar/ListProject.tsx
+++ b/src/components/sidebar/ListProject.tsx
@@ -1,0 +1,30 @@
+import { Link, useParams } from 'react-router-dom';
+import type { ProjectType } from '@/types/project';
+
+type ListProjectProps = {
+  data: ProjectType[];
+  targetId?: string;
+};
+
+export default function ListProject({ data, targetId }: ListProjectProps) {
+  const { teamId } = useParams();
+
+  return (
+    <ul className="grow overflow-auto">
+      {data.map((item) => (
+        <li
+          key={item.id}
+          className={`relative cursor-pointer border-b bg-white hover:brightness-90 ${targetId === item.id && 'selected'}`}
+        >
+          <Link
+            to={`/teams/${teamId}/projects/${item.id}/calendar`}
+            className="flex h-30 flex-col justify-center px-10"
+          >
+            <small className="font-bold text-category">project</small>
+            <span>{item.title}</span>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/sidebar/ListSidebar.tsx
+++ b/src/components/sidebar/ListSidebar.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react';
+
+type ListSidebarProps = {
+  label?: string;
+  title: string;
+  children?: ReactNode | undefined;
+};
+
+// ToDo: 프로젝트 생성 등과 같은 버튼 기능 추가할 것
+export default function ListSidebar({ label, title, children }: ListSidebarProps) {
+  return (
+    <aside className="mr-10 flex w-1/3 flex-col border border-list bg-contents-box">
+      <div className="flex min-h-30 items-center justify-between bg-sub px-10">
+        <div>
+          {label && <small className="mr-5 font-bold text-main">{label}</small>}
+          <span className="text-emphasis">{title}</span>
+        </div>
+      </div>
+      {children}
+    </aside>
+  );
+}

--- a/src/layouts/ProjectLayout.tsx
+++ b/src/layouts/ProjectLayout.tsx
@@ -1,51 +1,35 @@
 import { useMemo } from 'react';
 import { RiSettings5Fill } from 'react-icons/ri';
-import { Link, NavLink, Outlet, useParams } from 'react-router-dom';
+import { NavLink, Outlet, useParams } from 'react-router-dom';
 
-const dummy = [
-  { id: '1', title: '캘린더 만들기1' },
-  { id: '2', title: '캘린더 만들기2' },
-  { id: '3', title: '캘린더 만들기3' },
-  { id: '4', title: '캘린더 만들기4' },
-  { id: '5', title: '캘린더 만들기5' },
-  { id: '6', title: '캘린더 만들기6' },
-  { id: '7', title: '캘린더 만들기7' },
-  { id: '8', title: '캘린더 만들기8' },
-  { id: '9', title: '캘린더 만들기9' },
-  { id: '10', title: '캘린더 만들기10' },
-];
+import ListSidebar from '@components/sidebar/ListSidebar';
+import ListProject from '@components/sidebar/ListProject';
 
-// ToDo: 사이드바 공용 컴포넌트로 추출하기
+const dummy = {
+  teamName: '김찌와 소주',
+  data: [
+    { id: '1', title: '캘린더 만들기1' },
+    { id: '2', title: '캘린더 만들기2' },
+    { id: '3', title: '캘린더 만들기3' },
+    { id: '4', title: '캘린더 만들기4' },
+    { id: '5', title: '캘린더 만들기5' },
+    { id: '6', title: '캘린더 만들기6' },
+    { id: '7', title: '캘린더 만들기7' },
+    { id: '8', title: '캘린더 만들기8' },
+    { id: '9', title: '캘린더 만들기9' },
+    { id: '10', title: '캘린더 만들기10' },
+  ],
+};
+
 export default function ProjectLayout() {
-  const { teamId, projectId } = useParams();
-  const target = useMemo(() => dummy.find((d) => d.id === projectId), [projectId]);
+  const { projectId } = useParams();
+  const target = useMemo(() => dummy.data.find((d) => d.id === projectId), [projectId]);
 
   return (
     <section className="flex h-full p-15">
-      <aside className="mr-10 flex w-1/3 flex-col border border-list bg-contents-box">
-        <div className="flex min-h-30 items-center justify-between bg-sub px-10">
-          <div>
-            <small className="mr-5 font-bold text-main">team</small>
-            <span className="text-emphasis">김찌와소주</span>
-          </div>
-        </div>
-        <ul className="grow overflow-auto">
-          {dummy.map((v) => (
-            <li
-              key={v.id}
-              className={`relative cursor-pointer border-b bg-white hover:brightness-90 ${projectId === v.id && 'selected'}`}
-            >
-              <Link
-                to={`/teams/${teamId}/projects/${v.id}/calendar`}
-                className="flex h-30 flex-col justify-center px-10"
-              >
-                <small className="font-bold text-category">project</small>
-                <span>{v.title}</span>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </aside>
+      <ListSidebar label="team" title={dummy.teamName}>
+        <ListProject data={dummy.data} targetId={projectId} />
+      </ListSidebar>
       <section className="flex w-2/3 flex-col border border-list bg-contents-box">
         <header className="flex h-30 items-center justify-between border-b p-10">
           <div>
@@ -59,18 +43,12 @@ export default function ProjectLayout() {
         <div className="grow p-10">
           <ul className="flex border-b *:mr-15">
             <li>
-              <NavLink
-                to={`/teams/${teamId}/projects/${projectId}/calendar`}
-                className={({ isActive }) => (isActive ? 'text-main' : 'text-emphasis')}
-              >
+              <NavLink to="calendar" className={({ isActive }) => (isActive ? 'text-main' : 'text-emphasis')}>
                 Calendar
               </NavLink>
             </li>
             <li>
-              <NavLink
-                to={`/teams/${teamId}/projects/${projectId}/kanban`}
-                className={({ isActive }) => (isActive ? 'text-main' : 'text-emphasis')}
-              >
+              <NavLink to="kanban" className={({ isActive }) => (isActive ? 'text-main' : 'text-emphasis')}>
                 Kanban
               </NavLink>
             </li>

--- a/src/types/ProjectType.tsx
+++ b/src/types/ProjectType.tsx
@@ -1,5 +1,5 @@
 // ToDo: API 설계 완료시 데이터 타입 변경할 것
-export type ProjectType = {
+export type Project = {
   id: string;
   title: string;
 };

--- a/src/types/project.tsx
+++ b/src/types/project.tsx
@@ -1,0 +1,5 @@
+// ToDo: API 설계 완료시 데이터 타입 변경할 것
+export type ProjectType = {
+  id: string;
+  title: string;
+};


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] **\[UI\]** CSS 등 사용자 UI 디자인 추가/삭제/변경 했어요.

## Related Issues
#21 특정 프로젝트 관리 UI 작성

## What does this PR do?
- [x] ProjectLayout의 Sidebar 부분을 공용 컴포넌트로 추출
- [x] 불필요한 .gitkeep 파일 삭제

## Other information
진주님 이번에 만든 공용 사이드바는 사용자 개인정보 수정 페이지와 모든 프로젝트 관리 페이지의 사이드바에서 사용할 수 있다고 생각합니다. 문제는 모든 프로젝트 관리 페이지의 팀 생성 버튼에 대한 부분을 ToDo 주석으로 남겨둔 상황이라 이후에 필요하실 때 추가적으로 정의해주셨으면 합니다.