### PR TITLE
Feat: #63 수행자 목록 UI 추가 & 수행자 추가/삭제 기능 구현

### DIFF
--- a/src/components/modal/task/ModalTaskForm.tsx
+++ b/src/components/modal/task/ModalTaskForm.tsx
@@ -2,17 +2,19 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { DateTime } from 'luxon';
 import { useForm } from 'react-hook-form';
 import { IoSearch } from 'react-icons/io5';
+import { IoMdCloseCircle } from 'react-icons/io';
 
 import { TASK_VALIDATION_RULES } from '@constants/formValidationRules';
 import ToggleButton from '@components/common/ToggleButton';
 import DuplicationCheckInput from '@components/common/DuplicationCheckInput';
+import useToast from '@hooks/useToast';
 import useAxios from '@hooks/useAxios';
 import useTaskQuery from '@hooks/query/useTaskQuery';
 import useStatusQuery from '@hooks/query/useStatusQuery';
 import { findUserByProject } from '@services/projectService';
 
 import type { SubmitHandler } from 'react-hook-form';
-import type { User } from '@/types/UserType';
+import type { UserWithRole } from '@/types/UserType';
 import type { Project } from '@/types/ProjectType';
 import type { Task, TaskForm } from '@/types/TaskType';
 
@@ -29,11 +31,12 @@ export default function ModalTaskForm({ formId, project, taskId, onSubmit }: Mod
   const abortControllerRef = useRef<AbortController | null>(null);
   const [hasDeadline, setHasDeadline] = useState(false);
   const [keyword, setKeyword] = useState('');
-  const [workers, setWorkers] = useState<User[]>([]);
+  const [workers, setWorkers] = useState<UserWithRole[]>([]);
 
   const { statusList } = useStatusQuery(projectId, taskId);
   const { taskNameList } = useTaskQuery(projectId);
   const { data, loading, clearData, fetchData } = useAxios(findUserByProject);
+  const { toastInfo } = useToast();
 
   // ToDo: 상태 수정 모달 작성시 기본값 설정 방식 변경할 것
   const {
@@ -49,6 +52,7 @@ export default function ModalTaskForm({ formId, project, taskId, onSubmit }: Mod
     defaultValues: {
       name: '',
       content: '',
+      userId: [],
       startDate: DateTime.fromJSDate(new Date()).toFormat('yyyy-LL-dd'),
       endDate: DateTime.fromJSDate(new Date()).toFormat('yyyy-LL-dd'),
       statusId: statusList[0].statusId,
@@ -86,24 +90,33 @@ export default function ModalTaskForm({ formId, project, taskId, onSubmit }: Mod
   const handleSearchClick = () => searchUsers();
 
   const handleSearchKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key.toLocaleLowerCase() === 'enter') {
+    if (e.key.toLowerCase() === 'enter') {
       e.preventDefault();
       searchUsers();
     }
   };
 
-  const handleUserClick = (user: User) => {
-    setWorkers((prev) => [...prev, user]);
+  const handleUserClick = (user: UserWithRole) => {
+    const isIncludedUser = workers.find((worker) => worker.userId === user.userId);
+    if (isIncludedUser) return toastInfo('이미 포함된 수행자입니다');
+
+    const newWorkers = [...workers, user];
+    const workersIdList = newWorkers.map((worker) => worker.userId);
+    setWorkers(newWorkers);
+    setValue('userId', workersIdList);
     setKeyword('');
     clearData();
   };
 
+  const handleDeleteClick = (user: UserWithRole) => {
+    const filteredWorker = workers.filter((worker) => worker.userId !== user.userId);
+    const workersIdList = filteredWorker.map((worker) => worker.userId);
+    setWorkers(filteredWorker);
+    setValue('userId', workersIdList);
+  };
+
   return (
-    <form
-      id={formId}
-      className="mb-20 flex w-4/5 max-w-375 grow flex-col justify-center"
-      onSubmit={handleSubmit(onSubmit)}
-    >
+    <form id={formId} className="mb-20 flex w-4/5 grow flex-col justify-center" onSubmit={handleSubmit(onSubmit)}>
       {/* ToDo: 상태 선택 리팩토링 할 것 */}
       <div className="flex items-center justify-start gap-4">
         {statusList.map((status) => {
@@ -187,7 +200,7 @@ export default function ModalTaskForm({ formId, project, taskId, onSubmit }: Mod
               value={keyword}
               onChange={handleKeywordChange}
               onKeyDown={handleSearchKeyUp}
-              placeholder="닉네임으로 검색해주세요."
+              placeholder="닉네임을 검색해주세요."
             />
             <button
               type="button"
@@ -198,7 +211,7 @@ export default function ModalTaskForm({ formId, project, taskId, onSubmit }: Mod
               <IoSearch className="size-15 text-emphasis hover:text-black" />
             </button>
             {keyword && !loading && (
-              <ul className="invisible absolute left-0 right-0 rounded-md border-2 bg-white group-focus-within:visible">
+              <ul className="invisible absolute left-0 right-0 max-h-110 overflow-auto rounded-md border-2 bg-white group-focus-within:visible">
                 {data && data.length === 0 ? (
                   <div className="h-20 border px-10 leading-8">&apos;{keyword}&apos; 의 검색 결과가 없습니다.</div>
                 ) : (
@@ -221,6 +234,17 @@ export default function ModalTaskForm({ formId, project, taskId, onSubmit }: Mod
             )}
           </section>
         </label>
+        <section className="flex w-full flex-wrap items-center gap-4">
+          {workers.map((user) => (
+            <div key={user.userId} className="flex items-center space-x-4 rounded-md bg-button px-5">
+              <div>{user.roleName}</div>
+              <div>{user.nickname}</div>
+              <button type="button" aria-label="delete-worker" onClick={() => handleDeleteClick(user)}>
+                <IoMdCloseCircle className="text-error" />
+              </button>
+            </div>
+          ))}
+        </section>
       </div>
 
       <label htmlFor="content" className="mb-20">

--- a/src/layouts/ModalLayout.tsx
+++ b/src/layouts/ModalLayout.tsx
@@ -20,7 +20,7 @@ export default function ModalLayout({ onClose, children }: ModalLayoutProps) {
       className="absolute bottom-0 left-0 right-0 top-0 z-20 flex items-center justify-center bg-black/50"
       tabIndex={-1}
     >
-      <div className="flex h-4/5 max-h-375 min-w-375 flex-col items-center overflow-auto bg-white p-20">{children}</div>
+      <div className="flex h-4/5 max-h-375 w-375 flex-col items-center overflow-auto bg-white p-20">{children}</div>
     </div>
   );
 }

--- a/src/layouts/page/ProjectLayout.tsx
+++ b/src/layouts/page/ProjectLayout.tsx
@@ -53,10 +53,10 @@ export default function ProjectLayout() {
                 </li>
               </ul>
               <div className="text-main *:ml-10">
-                <button type="button" onClick={openTaskModal}>
+                <button type="button" className="outline-none" onClick={openTaskModal}>
                   + 할일 추가
                 </button>
-                <button type="button" onClick={openStatusModal}>
+                <button type="button" className="outline-none" onClick={openStatusModal}>
                   + 상태 추가
                 </button>
               </div>

--- a/src/mocks/mockData.ts
+++ b/src/mocks/mockData.ts
@@ -205,7 +205,7 @@ export const ROLE_DUMMY: Role[] = [
   },
   {
     roleId: 4,
-    roleName: 'Admin',
+    roleName: 'ADMIN',
     roleType: 'PROJECT',
   },
   {
@@ -215,7 +215,7 @@ export const ROLE_DUMMY: Role[] = [
   },
   {
     roleId: 6,
-    roleName: 'Assignee',
+    roleName: 'ASSIGNEE',
     roleType: 'PROJECT',
   },
 ] as const;

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -1,6 +1,6 @@
 import { authAxios } from '@services/axiosProvider';
 import type { AxiosRequestConfig } from 'axios';
-import type { User } from '@/types/UserType';
+import type { User, UserWithRole } from '@/types/UserType';
 import type { Project } from '@/types/ProjectType';
 
 /**
@@ -11,12 +11,12 @@ import type { Project } from '@/types/ProjectType';
  * @param {Project['projectId']} projectId - 프로젝트 아이디
  * @param {User['nickname']} nickname - 유저 닉네임
  * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
- * @returns {Promise<AxiosResponse<User[]>>}
+ * @returns {Promise<AxiosResponse<UserWithRole[]>>}
  */
 export async function findUserByProject(
   projectId: Project['projectId'],
   nickname: User['nickname'],
   axiosConfig: AxiosRequestConfig = {},
 ) {
-  return authAxios.get<User[]>(`project/${projectId}/user/search?nickname=${nickname}`, axiosConfig);
+  return authAxios.get<UserWithRole[]>(`project/${projectId}/user/search?nickname=${nickname}`, axiosConfig);
 }

--- a/src/types/RoleType.tsx
+++ b/src/types/RoleType.tsx
@@ -1,5 +1,5 @@
 export type Role = {
   roleId: number;
-  roleName: 'HEAD' | 'LEADER' | 'MATE' | 'Admin' | 'Assignee';
+  roleName: 'HEAD' | 'LEADER' | 'MATE' | 'ADMIN' | 'ASSIGNEE';
   roleType: 'TEAM' | 'PROJECT';
 };

--- a/src/types/TaskType.tsx
+++ b/src/types/TaskType.tsx
@@ -13,17 +13,19 @@ type StatusKeyMapping = {
 export type Task = {
   taskId: number;
   name: string;
-  order: number;
   userId: number;
-  files: string[];
+  // content: string;
   startDate: string;
   endDate: string;
+  files: string[];
+  order: number;
 };
 
 // ToDo: Task 추가 모달 작업시 같이 정의할 것
 export type TaskForm = {
   name: string;
   content: string;
+  userId: number[];
   startDate: string;
   endDate: string;
   statusId: number;

--- a/src/types/UserType.tsx
+++ b/src/types/UserType.tsx
@@ -1,3 +1,5 @@
+import { Role } from '@/types/RoleType';
+
 export type User = {
   userId: number;
   id: string | null;
@@ -8,6 +10,8 @@ export type User = {
   links: string[];
   profileUrl: string | null;
 };
+
+export type UserWithRole = User & Role;
 
 export type UserSignUpForm = Omit<User, 'userId' | 'provider'> & {
   code: string;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] **\[Feat\]** 새로운 기능을 추가했어요.
- [x] **\[UI\]** CSS 등 사용자 UI 디자인 추가/삭제/변경 했어요.

## Related Issues
#63 할일 등록 모달 UI 작성 및 기능 개발

## What does this PR do?
- [x] 수행자 목록 UI 추가
- [x] 수행자 검색후 유저 클릭시 수행자 목록 추가 기능 구현
- [x] 수행자 목록 삭제 기능 구현
- [x] 중복된 사용자 선택시 '이미 등록된 수행자입니다' 토스트 메세지 출력

## Suggestion
**수행자 목록 UI**
![수행자 목록 UI](https://github.com/user-attachments/assets/f4f585b7-8824-412c-adf7-aed5ac6499e1)

 **사용 가능한 체크 마크**
![체스 마크](https://github.com/user-attachments/assets/0bac4e2a-53d5-4161-b88d-de6c361ffe4d)

수행자 권한(`ADMIN`, `LEADER`, `ASSIGNEE`) UI가 별로 이쁘지 않아서 간단한 이모티콘으로 변경해보는게 어떨까 생각해봤습니다. 문득 체스 마크를 권한 등급으로 표현해보는게 어떨까라는 생각이 들었어요. 세계적으로 유명한 게임이고 각 체스말들의 등급이 사용자에게 직관적으로 느껴지지 않을까 싶어요. 그래서 권한 부분을 체스 마크로 변경해보는게 어떨까요?

## View
![화면 예시](https://github.com/user-attachments/assets/762c6e53-bfb0-4b12-8ecc-c0720100daa4)


