### PR TITLE
Fix: #90 마크다운 코드 블록 내 개행문자가 <br />로 치환되는 문제 해결

### DIFF
--- a/src/components/common/CustomMarkdown.tsx
+++ b/src/components/common/CustomMarkdown.tsx
@@ -137,10 +137,25 @@ const component: Partial<Components> = {
 };
 
 function getChangedMarkdownForLineBreak(markdown: string) {
-  return markdown
-    .split('\n')
-    .map((sentence) => (sentence === '' ? '\n<br />\n' : sentence))
-    .join('\n');
+  const lines = markdown.split('\n');
+
+  let inCodeBlock = false;
+  const resultLines: string[] = [];
+  lines.forEach((line) => {
+    if (line.trim().startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      resultLines.push(line);
+      return;
+    }
+
+    if (!inCodeBlock && line.trim() === '') {
+      resultLines.push('\n<br/>\n');
+    } else {
+      resultLines.push(line);
+    }
+  });
+
+  return resultLines.join('\n');
 }
 
 export default function CustomMarkdown({ markdown }: CustomMarkdownProps) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] **\[Fix\]** 버그를 수정했어요.

## Related Issues
- close #90 

## What does this PR do?
- [x] 코드 블록내 개행문자도 같이 `<br />` 태그로 치환되는 문제 해결

## Other information
이전에는 markdown 문자열을 `\n`문자를 기준으로 분리하고, 빈 문자열이 등장하는 구간을 의도적인 개행 라인으로 판정하여 `<br />` 태그로 치환하도록 했습니다. 문제는 이 처리 과정이 코드 블록 내부의 개행 라인에도 영향을 줬습니다. 이를 해결하기 위해 코드 블록의 시작과 끝 사이에 있는 문장에 대해서는 `<br />`을 치환하지 못하도록 처리를 추가하였습니다.

추가적으로 코드 블록의 시작과 끝을 알려주는 ` ``` ` 문자가 짝수로 떨어지냐 홀수로 떨어지냐는 중요한 문제가 아니었습니다. 처음에 저도 ` ``` ` 문자가 홀수로 떨어지면 마지막 ` ``` `은 코드블록을 충족하지 않아  예외적인 처리를 추가해야 한다고 생각했지만,  홀수로 존재하는 ` ``` `에 대해서도 코드 블록으로 인식하고 마크다운을 파싱하는 것을 확인했습니다. 때문에 특별한 분기 없이 처리할 수 있었습니다.

## View
**처리 변경 전**
![화면 예시4](https://github.com/user-attachments/assets/ec3a4e83-b25f-44f9-b737-f049585849ce)

**처리 변경 후**
![화면 예시3](https://github.com/user-attachments/assets/222774a3-79e5-413c-a829-1e8806f490f7)