### PR TITLE
Feat: #104 일정 순서 변경 API를 이용하여 칸반 보드 DnD로 일정의 순서를 변경하는 기능 구현

### DIFF
--- a/src/components/modal/task/ModalTaskForm.tsx
+++ b/src/components/modal/task/ModalTaskForm.tsx
@@ -14,7 +14,7 @@ import CustomMarkdown from '@components/common/CustomMarkdown';
 import DuplicationCheckInput from '@components/common/DuplicationCheckInput';
 import useToast from '@hooks/useToast';
 import useAxios from '@hooks/useAxios';
-import { useTasksQuery } from '@hooks/query/useTaskQuery';
+import { useReadStatusTasks } from '@hooks/query/useTaskQuery';
 import { useReadStatuses } from '@hooks/query/useStatusQuery';
 import { convertBytesToString } from '@utils/converter';
 import { findUserByProject } from '@services/projectService';
@@ -45,7 +45,7 @@ export default function ModalTaskForm({ formId, project, taskId, onSubmit }: Mod
   const [files, setFiles] = useState<CustomFile[]>([]);
 
   const { statusList, isStatusLoading } = useReadStatuses(projectId, taskId);
-  const { taskNameList } = useTasksQuery(projectId);
+  const { taskNameList } = useReadStatusTasks(projectId);
   const { data, loading, clearData, fetchData } = useAxios(findUserByProject);
   const { toastInfo, toastWarn } = useToast();
 

--- a/src/hooks/query/useStatusQuery.ts
+++ b/src/hooks/query/useStatusQuery.ts
@@ -102,7 +102,7 @@ export function useCreateStatus(projectId: Project['projectId']) {
     onSuccess: () => {
       toastSuccess('프로젝트 상태를 추가하였습니다.');
       queryClient.invalidateQueries({
-        queryKey: ['projects', projectId, 'statuses'],
+        queryKey: ['projects', projectId],
       });
     },
   });
@@ -119,7 +119,7 @@ export function useUpdateStatus(projectId: Project['projectId'], statusId: Proje
     onSuccess: () => {
       toastSuccess('프로젝트 상태를 수정했습니다.');
       queryClient.invalidateQueries({
-        queryKey: ['projects', projectId, 'statuses'],
+        queryKey: ['projects', projectId],
       });
     },
   });

--- a/src/hooks/query/useTaskQuery.ts
+++ b/src/hooks/query/useTaskQuery.ts
@@ -1,7 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
-import { findTaskList } from '@services/taskService';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { findTaskList, updateTaskOrder } from '@services/taskService';
 
-import type { TaskListWithStatus } from '@/types/TaskType';
+import type { TaskListWithStatus, TaskOrder } from '@/types/TaskType';
 import type { Project } from '@/types/ProjectType';
 
 function getTaskNameList(taskList: TaskListWithStatus[]) {
@@ -31,4 +31,36 @@ export function useReadStatusTasks(projectId: Project['projectId']) {
   const taskNameList = getTaskNameList(statusTaskList);
 
   return { statusTaskList, taskNameList, isTaskLoading, isTaskError, taskError };
+}
+
+export function useUpdateTasksOrder(projectId: Project['projectId']) {
+  const queryClient = useQueryClient();
+  const queryKey = ['projects', projectId, 'tasks'];
+
+  const mutation = useMutation({
+    mutationFn: (newStatusTaskList: TaskListWithStatus[]) => {
+      const taskOrders: TaskOrder[] = newStatusTaskList
+        .map((statusTask) => {
+          const { statusId, tasks } = statusTask;
+          const taskOrder = tasks.map(({ taskId, sortOrder }) => ({ statusId, taskId, sortOrder }));
+          return taskOrder;
+        })
+        .flat();
+      return updateTaskOrder(projectId, { tasks: taskOrders });
+    },
+    onMutate: async (newStatusTaskList: TaskListWithStatus[]) => {
+      await queryClient.cancelQueries({ queryKey });
+
+      const previousStatusTaskList = queryClient.getQueryData(queryKey);
+      queryClient.setQueryData(queryKey, newStatusTaskList);
+
+      return { previousStatusTaskList };
+    },
+    onError: (err, newStatusTaskList, context) => {
+      queryClient.setQueryData(queryKey, context?.previousStatusTaskList);
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey }),
+  });
+
+  return mutation;
 }

--- a/src/hooks/query/useTaskQuery.ts
+++ b/src/hooks/query/useTaskQuery.ts
@@ -14,9 +14,9 @@ function getTaskNameList(taskList: TaskListWithStatus[]) {
 }
 
 // Todo: Task Query CUD로직 작성하기
-export function useTasksQuery(projectId: Project['projectId']) {
+export function useReadStatusTasks(projectId: Project['projectId']) {
   const {
-    data: taskList = [],
+    data: statusTaskList = [],
     isLoading: isTaskLoading,
     isError: isTaskError,
     error: taskError,
@@ -28,7 +28,7 @@ export function useTasksQuery(projectId: Project['projectId']) {
     },
   });
 
-  const taskNameList = getTaskNameList(taskList);
+  const taskNameList = getTaskNameList(statusTaskList);
 
-  return { taskList, taskNameList, isTaskLoading, isTaskError, taskError };
+  return { statusTaskList, taskNameList, isTaskLoading, isTaskError, taskError };
 }

--- a/src/hooks/query/useTaskQuery.ts
+++ b/src/hooks/query/useTaskQuery.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { findTaskList, updateTaskOrder } from '@services/taskService';
+import useToast from '@hooks/useToast';
 
 import type { TaskListWithStatus, TaskOrder } from '@/types/TaskType';
 import type { Project } from '@/types/ProjectType';
@@ -34,6 +35,7 @@ export function useReadStatusTasks(projectId: Project['projectId']) {
 }
 
 export function useUpdateTasksOrder(projectId: Project['projectId']) {
+  const { toastError } = useToast();
   const queryClient = useQueryClient();
   const queryKey = ['projects', projectId, 'tasks'];
 
@@ -42,8 +44,7 @@ export function useUpdateTasksOrder(projectId: Project['projectId']) {
       const taskOrders: TaskOrder[] = newStatusTaskList
         .map((statusTask) => {
           const { statusId, tasks } = statusTask;
-          const taskOrder = tasks.map(({ taskId, sortOrder }) => ({ statusId, taskId, sortOrder }));
-          return taskOrder;
+          return tasks.map(({ taskId, sortOrder }) => ({ statusId, taskId, sortOrder }));
         })
         .flat();
       return updateTaskOrder(projectId, { tasks: taskOrders });
@@ -57,9 +58,9 @@ export function useUpdateTasksOrder(projectId: Project['projectId']) {
       return { previousStatusTaskList };
     },
     onError: (err, newStatusTaskList, context) => {
+      toastError('일정 순서 변경에 실패 하였습니다. 잠시후 다시 진행해주세요.');
       queryClient.setQueryData(queryKey, context?.previousStatusTaskList);
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey }),
   });
 
   return mutation;

--- a/src/mocks/mockHash.ts
+++ b/src/mocks/mockHash.ts
@@ -1,0 +1,30 @@
+import { PROJECT_DUMMY, ROLE_DUMMY, STATUS_DUMMY, TASK_DUMMY, TEAM_DUMMY, USER_DUMMY } from '@mocks/mockData';
+import type { User } from '@/types/UserType';
+import type { Role } from '@/types/RoleType';
+import type { Team } from '@/types/TeamType';
+import type { Project } from '@/types/ProjectType';
+import type { ProjectStatus } from '@/types/ProjectStatusType';
+import type { Task } from '@/types/TaskType';
+
+type Hash<T> = {
+  [key: string | number]: T;
+};
+
+// ToDo: MSW 처리중 해쉬 테이블 처리를 사용하는 부분 대체해주기
+export const USERS_HASH: Hash<User> = {};
+USER_DUMMY.forEach((user) => (USERS_HASH[user.userId] = user));
+
+export const ROLES_HASH: Hash<Role> = {};
+ROLE_DUMMY.forEach((role) => (ROLES_HASH[role.roleId] = role));
+
+export const TEAMS_HASH: Hash<Team> = {};
+TEAM_DUMMY.forEach((team) => (TEAMS_HASH[team.teamId] = team));
+
+export const PROJECTS_HASH: Hash<Project> = {};
+PROJECT_DUMMY.forEach((project) => (PROJECTS_HASH[project.projectId] = project));
+
+export const STATUSES_HASH: Hash<ProjectStatus> = {};
+STATUS_DUMMY.forEach((status) => (STATUSES_HASH[status.statusId] = status));
+
+export const TASK_HASH: Hash<Task> = {};
+TASK_DUMMY.forEach((task) => (TASK_HASH[task.taskId] = task));

--- a/src/mocks/services/taskServiceHandler.ts
+++ b/src/mocks/services/taskServiceHandler.ts
@@ -1,9 +1,12 @@
 import { http, HttpResponse } from 'msw';
 import { STATUS_DUMMY, TASK_DUMMY } from '@mocks/mockData';
+import { STATUSES_HASH, TASK_HASH } from '@mocks/mockHash';
+import type { TaskOrderForm } from '@/types/TaskType';
 
 const BASE_URL = import.meta.env.VITE_BASE_URL;
 
 const taskServiceHandler = [
+  // 일정 목록 조회 API
   http.get(`${BASE_URL}/project/:projectId/task`, ({ request, params }) => {
     const accessToken = request.headers.get('Authorization');
     const { projectId } = params;
@@ -12,11 +15,35 @@ const taskServiceHandler = [
 
     const statusList = STATUS_DUMMY.filter((status) => status.projectId === Number(projectId));
     const statusTaskList = statusList.map((status) => {
-      const tasks = TASK_DUMMY.filter((task) => task.statusId === status.statusId);
+      const tasks = TASK_DUMMY.filter((task) => task.statusId === status.statusId).sort(
+        (a, b) => a.sortOrder - b.sortOrder,
+      );
       return { ...status, tasks };
     });
 
     return HttpResponse.json(statusTaskList);
+  }),
+  // 일정 순서 변경 API
+  http.patch(`${BASE_URL}/project/:projectId/task/order`, async ({ request, params }) => {
+    const accessToken = request.headers.get('Authorization');
+    const { tasks: taskOrders } = (await request.json()) as TaskOrderForm;
+    const { projectId } = params;
+
+    if (!accessToken) return new HttpResponse(null, { status: 401 });
+
+    for (let i = 0; i < taskOrders.length; i++) {
+      const { taskId, statusId, sortOrder } = taskOrders[i];
+
+      const target = TASK_HASH[taskId];
+      if (!target) return new HttpResponse(null, { status: 404 });
+
+      const status = STATUSES_HASH[statusId];
+      if (status.projectId !== Number(projectId)) return new HttpResponse(null, { status: 400 });
+
+      target.statusId = statusId;
+      target.sortOrder = sortOrder;
+    }
+    return new HttpResponse(null, { status: 204 });
   }),
 ];
 

--- a/src/pages/project/CalendarPage.tsx
+++ b/src/pages/project/CalendarPage.tsx
@@ -7,12 +7,12 @@ import CustomEventWrapper from '@components/task/calendar/CustomEventWrapper';
 import UpdateModalTask from '@components/modal/task/UpdateModalTask';
 import useModal from '@hooks/useModal';
 import useProjectContext from '@hooks/useProjectContext';
+import { useReadStatusTasks } from '@hooks/query/useTaskQuery';
 import Validator from '@utils/Validator';
 import { TaskListWithStatus, TaskWithStatus } from '@/types/TaskType';
 import { CustomEvent } from '@/types/CustomEventType';
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 import '@/customReactBigCalendar.css';
-import { useTasksQuery } from '@/hooks/query/useTaskQuery';
 
 function getCalendarTask(statusTasks: TaskListWithStatus[]) {
   const calendarTasks: TaskWithStatus[] = [];
@@ -38,7 +38,7 @@ export default function CalendarPage() {
   const { showModal, openModal, closeModal } = useModal();
   const [selectedTask, setSelectedTask] = useState<TaskWithStatus>();
   const [date, setDate] = useState<Date>(() => DateTime.now().toJSDate());
-  const { taskList, isTaskLoading, isTaskError, taskError } = useTasksQuery(project.projectId);
+  const { statusTaskList, isTaskLoading, isTaskError, taskError } = useReadStatusTasks(project.projectId);
 
   const handleNavigate = useCallback((newDate: Date) => setDate(newDate), [setDate]);
 
@@ -77,7 +77,7 @@ export default function CalendarPage() {
   );
 
   const state = {
-    events: getCalendarTask(taskList)
+    events: getCalendarTask(statusTaskList)
       .map((task) => ({
         title: task.name,
         start: new Date(task.startDate),

--- a/src/pages/project/KanbanPage.tsx
+++ b/src/pages/project/KanbanPage.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
 import { DragDropContext, Droppable, DropResult } from '@hello-pangea/dnd';
 import ProjectStatusContainer from '@components/task/kanban/ProjectStatusContainer';
 import { DND_DROPPABLE_PREFIX, DND_TYPE } from '@constants/dnd';
 import deepClone from '@utils/deepClone';
 import { parsePrefixId } from '@utils/converter';
-import { TASK_SPECIAL_DUMMY } from '@mocks/mockData';
+import { useReadStatusTasks } from '@hooks/query/useTaskQuery';
+import useProjectContext from '@hooks/useProjectContext';
 import type { Task, TaskListWithStatus } from '@/types/TaskType';
 
 function createChangedStatus(statusTasks: TaskListWithStatus[], dropResult: DropResult) {
@@ -48,10 +48,10 @@ function createChangedTasks(statusTasks: TaskListWithStatus[], dropResult: DropR
   return newStatusTasks;
 }
 
-// ToDo: TASK_SPECIAL_DUMMY 부분을 react query로 변경할 것, mutation 작업이 같이 들어가야함
 // ToDo: DnD시 가시성을 위한 애니메이션 처리 추가할 것
 export default function KanbanPage() {
-  const [statusTasks, setStatusTasks] = useState<TaskListWithStatus[]>(TASK_SPECIAL_DUMMY);
+  const { project } = useProjectContext();
+  const { statusTaskList } = useReadStatusTasks(project.projectId);
 
   const handleDragEnd = (dropResult: DropResult) => {
     const { source, destination, type } = dropResult;
@@ -60,14 +60,14 @@ export default function KanbanPage() {
     if (source.droppableId === destination.droppableId && source.index === destination.index) return;
 
     if (type === DND_TYPE.STATUS) {
-      const newStatusTasks = createChangedStatus(statusTasks, dropResult);
-      return setStatusTasks(newStatusTasks);
+      const newStatusList = createChangedStatus(statusTaskList, dropResult);
+      // return setStatusTasks(newStatusList);
     }
 
     if (type === DND_TYPE.TASK) {
       const isSameStatus = source.droppableId === destination.droppableId;
-      const newStatusTasks = createChangedTasks(statusTasks, dropResult, isSameStatus);
-      return setStatusTasks(newStatusTasks);
+      const newStatusList = createChangedTasks(statusTaskList, dropResult, isSameStatus);
+      // return setStatusTasks(newStatusTasks);
     }
   };
 
@@ -80,7 +80,7 @@ export default function KanbanPage() {
             ref={statusDropProvided.innerRef}
             {...statusDropProvided.droppableProps}
           >
-            {statusTasks.map((statusTask) => (
+            {statusTaskList.map((statusTask) => (
               <ProjectStatusContainer key={statusTask.statusId} statusTask={statusTask} />
             ))}
             {statusDropProvided.placeholder}

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -2,10 +2,10 @@ import { authAxios } from '@services/axiosProvider';
 
 import type { AxiosRequestConfig } from 'axios';
 import type { Project } from '@/types/ProjectType';
-import type { TaskListWithStatus } from '@/types/TaskType';
+import type { TaskListWithStatus, TaskOrderForm } from '@/types/TaskType';
 
 /**
- * 프로젝트에 속한 모든 할일 목록 조회 API
+ * 프로젝트에 속한 모든 일정 목록 조회 API
  *
  * @export
  * @async
@@ -15,4 +15,22 @@ import type { TaskListWithStatus } from '@/types/TaskType';
  */
 export async function findTaskList(projectId: Project['projectId'], axiosConfig: AxiosRequestConfig = {}) {
   return authAxios.get<TaskListWithStatus[]>(`project/${projectId}/task`, axiosConfig);
+}
+
+/**
+ * 일정 순서 변경 API
+ *
+ * @export
+ * @async
+ * @param {Project['projectId']} projectId
+ * @param {TaskOrder} newOrder
+ * @param {AxiosRequestConfig} [axiosConfig={}]
+ * @returns {Promise<AxiosResponse<void>>}
+ */
+export async function updateTaskOrder(
+  projectId: Project['projectId'],
+  newOrderData: TaskOrderForm,
+  axiosConfig: AxiosRequestConfig = {},
+) {
+  return authAxios.patch(`project/${projectId}/task/order`, newOrderData, axiosConfig);
 }

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -9,7 +9,7 @@ import type { TaskListWithStatus, TaskOrderForm } from '@/types/TaskType';
  *
  * @export
  * @async
- * @param {Project['projectId']} projectId - 대상 프로젝트 ID
+ * @param {Project['projectId']} projectId      - 대상 프로젝트 ID
  * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
  * @returns {Promise<AxiosResponse<TaskListWithStatus[]>>}
  */
@@ -22,9 +22,9 @@ export async function findTaskList(projectId: Project['projectId'], axiosConfig:
  *
  * @export
  * @async
- * @param {Project['projectId']} projectId
- * @param {TaskOrder} newOrder
- * @param {AxiosRequestConfig} [axiosConfig={}]
+ * @param {Project['projectId']} projectId      - 프로젝트 ID
+ * @param {TaskOrder} newOrderData              - 새로 정렬된 일정 목록 객체
+ * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
  * @returns {Promise<AxiosResponse<void>>}
  */
 export async function updateTaskOrder(

--- a/src/types/TaskType.tsx
+++ b/src/types/TaskType.tsx
@@ -20,8 +20,10 @@ export type Task = {
   sortOrder: number;
 };
 
+export type TaskOrder = Pick<Task, 'statusId' | 'taskId' | 'sortOrder'>;
+export type TaskOrderForm = { tasks: TaskOrder[] };
+
 export type TaskForm = Omit<Task, 'taskId' | 'files'>;
 
 export type TaskWithStatus = RenameKeys<Omit<ProjectStatus, 'projectId'>, StatusKeyMapping> & Task;
-
 export type TaskListWithStatus = Omit<ProjectStatus, 'projectId'> & { tasks: Task[] };


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [X] **\[Feat\]** 새로운 기능을 추가했어요.
- [X] **\[Formatting\]** 코드 스타일 업데이트를 했어요(포맷팅, 변수명 변경 etc)

## Related Issues
- close #104 

## What does this PR do?
- [x] [React Query 커스텀훅명 변경]()
- [x] 일정 목록에 대해 더미 처리에서 커스텀훅 처리로 변경
- [x] 일정 순서 변경 API React Query 처리 추가
- [x] 일정 순서 변경 API MSW 처리 추가 
- [x] 일정 순서 변경 기능 구현

## Other information
React Query 참고자료
[공식문서: Optimistic Updates](https://tanstack.com/query/latest/docs/framework/react/guides/optimistic-updates#if-the-mutation-and-the-query-dont-live-in-the-same-component)
[공식문서: Filters](https://tanstack.com/query/latest/docs/framework/react/guides/filters#mutation-filters)
[공식문서: useMutation](https://tanstack.com/query/latest/docs/framework/react/reference/useMutation)
[공식문서: useMutationState](https://tanstack.com/query/latest/docs/framework/react/reference/useMutationState)

## Consideration
<details>
   <summary>1. 일정 순서 변경을 반영했을 때, 네트워크 요청을 처리하는 동안 변경된 내용을 부드럽게 화면에 표현하기 위해 낙관적 UI를  고려했습니다.</summary>
   
```
낙관적 UI를 만드는 방법은 크게 2가지였습니다. 첫 번째는 useMutation의 isPending과
variables를 이용하여 mutation이 pending 상태일 때, mutationFn에 전달한 변수를 가져와
보여주는 방법이었고, 두 번째 방법은 Query 캐시를 직접적으로 변경하는 방법이었습니다.

첫 번째 방법은 onSettled를 추가적으로 이용합니다. 그 이유는 error이든, success이든
캐시 데이터 무효화를 진행하여 새롭게 데이터를 가져오며, 데이터가 완전히 fetching될 때까지
await를 통해 기다려줌으로써 isPending을 시간을 늘리고, 그동안 낙관적 UI를 보여주기 위함입니다. 

두 번째 방법은 onMutate를 통해 useMutation의 mutate가 동작하기 전에 이전의
캐시 데이터를 보존하고, 새롭게 서버에 변경 요청한 데이터를 직접적으로 캐시에
넣어주는 방법을 사용합니다. onError시 보존한 이전 캐시 데이터로 다시 돌려줘 안전성도
챙길 수 있으며, 데이터를 원상 복구 할 때 별다른 서버 요청이 필요 없는 방법입니다.

저는 결과적으로 두 번째 방법을 사용했는데 그 이유는 다음과 같습니다.
1. 현재 일정 변경 이후에 파생되는 전체 일정 목록 조회 API는 일정 목록이 늘어남에 따라
데이터량이 무거워질 수 있습니다. 따라서 네트워크 통신을 최소화 하는 방법을 고려한
결과 두 번째 방법이 서버와의 통신 횟수를 줄일 수 있는 방법이었습니다.

2. 공식문서에서 첫 번째 방법은 결과적으로 캐시를 무효화하고 서버에 재요청을 통해
가져오기 때문에 네트워크 상태에 의존적이라고 합니다. 때문에 네트워크 상태에 의존하지
않으면서도 실패시 원래의 데이터를 보존할 수 있는 두 번째 방법이 더 안전하다고 생각했습니다.

추가적으로 onSuccess에서 invalidateQuery를 통해 캐시를 무효화하고
서버로부터 refetch를 하는 부분을 의도적으로 없앴습니다.  서버에 요청한 변경내역이
이미 캐시에 반영되어 있기 때문에 굳이 무효화 하여 refetch하는 것은 리소스 낭비라고
생각했기 때문입니다. 물론 staleTime이 최신화가 안되지만, staleTime이 지나 다시 가져와도
크게 문제가 없다고 판단하여 무효화를 최소화하는 방향을 선택했습니다.
```
</details>

<details>
   <summary>2.  일정 순서 변경 반영간 화면 깜박임 현상을 해결하기 위해, 지역 상태로 별도로 관리하도록 만들었습니다. </summary>

```
일정을 드래그 앤 드롭을 하여 이동하면, 일시적으로 드래그 전의 원본 상태를 보였다가 
변경된 화면으로 바뀌면서 깜박거리는 현상이 일어났습니다. 이는 화면에서 발생한 이벤트를
통해 mutate를 트리거 하고, 이때 캐시를 인위적으로 변경하는 동안 기존의 데이터를 참고하여
발생하는 문제였고, 이를 해결하기 위해서 별도의 지역 상태를 관리하여 변경을 반영하는
처리가 진행되는 동안에도 화면에 변경된 내용을 부드럽게 보여줄 수 있도록 만들었습니다.
같은 데이터를 내부 상태로 한 번 더 관리하고 있어 데이터 동기화에 신경을 써야하는 단점이
있지만, 사용자가 느끼는 불편함보다는 괜찮을 것이라 판단했습니다.
```

</details>


## View
**일정 순서 변경 반영에 실패한 경우**
![화면 예시1](https://github.com/user-attachments/assets/2f495fe2-048d-401c-882f-6b0f6db686a3)

**일정 순서 변경 반영에 성공한 경우**
![화면 예시2](https://github.com/user-attachments/assets/980f05e9-3ca6-402b-8e59-11ccf1317503)
