### PR TITLE
Feat: #105 상태 순서 변경 API를 이용하여 칸반 보드 DnD로 상태의 순서를 변경하는 기능 구현

### DIFF
--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -20,7 +20,7 @@ export async function findUserByProject(
   nickname: User['nickname'],
   axiosConfig: AxiosRequestConfig = {},
 ) {
-  return authAxios.get<UserWithRole[]>(`project/${projectId}/user/search?nickname=${nickname}`, axiosConfig);
+  return authAxios.get<UserWithRole[]>(`/project/${projectId}/user/search?nickname=${nickname}`, axiosConfig);
 }
 
 /**
@@ -33,5 +33,5 @@ export async function findUserByProject(
  * @returns {Promise<AxiosResponse<Project[]>>}
  */
 export async function getProjectList(teamId: Team['teamId'], axiosConfig: AxiosRequestConfig = {}) {
-  return authAxios.get<Project[]>(`team/${teamId}/project`, axiosConfig);
+  return authAxios.get<Project[]>(`/team/${teamId}/project`, axiosConfig);
 }

--- a/src/services/statusService.ts
+++ b/src/services/statusService.ts
@@ -70,5 +70,5 @@ export async function updateStatusesOrder(
   newOrderData: StatusOrderForm,
   axiosConfig: AxiosRequestConfig = {},
 ) {
-  return authAxios.patch(`/project/${projectId}/statusss/order`, newOrderData, axiosConfig);
+  return authAxios.patch(`/project/${projectId}/status/order`, newOrderData, axiosConfig);
 }

--- a/src/services/statusService.ts
+++ b/src/services/statusService.ts
@@ -1,7 +1,8 @@
 import { authAxios } from '@services/axiosProvider';
+
 import type { AxiosRequestConfig } from 'axios';
 import type { Project } from '@/types/ProjectType';
-import type { ProjectStatus, ProjectStatusForm } from '@/types/ProjectStatusType';
+import type { ProjectStatus, ProjectStatusForm, StatusOrderForm } from '@/types/ProjectStatusType';
 
 /**
  * 프로젝트 상태 목록 조회 API
@@ -52,4 +53,22 @@ export async function updateStatus(
   axiosConfig: AxiosRequestConfig = {},
 ) {
   return authAxios.patch(`/project/${projectId}/status/${statusId}`, formData, axiosConfig);
+}
+
+/**
+ * 상태 순서 변경 API
+ *
+ * @export
+ * @async
+ * @param {Project['projectId']} projectId      - 프로젝트 ID
+ * @param {StatusOrderForm} newOrderData        - 새로 정렬된 상태 목록 객체
+ * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
+ * @returns {Promise<AxiosResponse<void>>}
+ */
+export async function updateStatusesOrder(
+  projectId: Project['projectId'],
+  newOrderData: StatusOrderForm,
+  axiosConfig: AxiosRequestConfig = {},
+) {
+  return authAxios.patch(`/project/${projectId}/statusss/order`, newOrderData, axiosConfig);
 }

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -14,7 +14,7 @@ import type { TaskListWithStatus, TaskOrderForm } from '@/types/TaskType';
  * @returns {Promise<AxiosResponse<TaskListWithStatus[]>>}
  */
 export async function findTaskList(projectId: Project['projectId'], axiosConfig: AxiosRequestConfig = {}) {
-  return authAxios.get<TaskListWithStatus[]>(`project/${projectId}/task`, axiosConfig);
+  return authAxios.get<TaskListWithStatus[]>(`/project/${projectId}/task`, axiosConfig);
 }
 
 /**
@@ -32,5 +32,5 @@ export async function updateTaskOrder(
   newOrderData: TaskOrderForm,
   axiosConfig: AxiosRequestConfig = {},
 ) {
-  return authAxios.patch(`project/${projectId}/task/order`, newOrderData, axiosConfig);
+  return authAxios.patch(`/project/${projectId}/task/order`, newOrderData, axiosConfig);
 }

--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -18,5 +18,5 @@ async function findUserByTeam(
   nickname: User['nickname'],
   axiosConfig: AxiosRequestConfig = {},
 ) {
-  return authAxios.get<User[]>(`team/${teamId}/user/search?nickname=${nickname}`, axiosConfig);
+  return authAxios.get<User[]>(`/team/${teamId}/user/search?nickname=${nickname}`, axiosConfig);
 }

--- a/src/types/ProjectStatusType.tsx
+++ b/src/types/ProjectStatusType.tsx
@@ -6,6 +6,9 @@ export type ProjectStatus = {
   sortOrder: number;
 };
 
+export type StatusOrder = Pick<ProjectStatus, 'statusId' | 'sortOrder'>;
+export type StatusOrderForm = { statuses: StatusOrder[] };
+
 export type ProjectStatusForm = Pick<ProjectStatus, 'statusName' | 'colorCode' | 'sortOrder'>;
 
 export type UsableColor = Pick<ProjectStatus, 'colorCode'> & { isUsable: boolean };


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] **\[Feat\]** 새로운 기능을 추가했어요.
- [x] **\[Chore\]** 빌드 프로세스 변경, 의존성 패키지 업데이트 했어요.

## Related Issues
- close #105 

## What does this PR do?
- [x] 상태 순서 변경 API React Query 처리 추가
- [x] 상태 순서 변경 API MSW 처리 추가 
- [x] 상태 순서 변경 기능 구현
- [x] 기타 axios 요청 상대 경로 요청에서 절대경로 요청으로 변경

## View
**상태 순서 변경 반영에 실패한 경우**
![화면 예시2](https://github.com/user-attachments/assets/155a2a39-fe2a-48a6-8b8a-50fb01d68906)

**상태 순서 변경 반영에 성공한 경우**
![화면 예시](https://github.com/user-attachments/assets/c1742672-df4e-4dd4-a099-dc101fd64754)
