### PR TITLE
Feat: #114 일정 생성 API를 이용하여 일정 생성 기능 구현

### DIFF
--- a/src/components/modal/task/CreateModalTask.tsx
+++ b/src/components/modal/task/CreateModalTask.tsx
@@ -2,10 +2,13 @@ import ModalLayout from '@layouts/ModalLayout';
 import ModalPortal from '@components/modal/ModalPortal';
 import ModalTaskForm from '@components/modal/task/ModalTaskForm';
 import ModalFormButton from '@components/modal/ModalFormButton';
+import { useCreateStatusTask, useReadStatusTasks } from '@hooks/query/useTaskQuery';
 
 import type { SubmitHandler } from 'react-hook-form';
 import type { TaskForm } from '@/types/TaskType';
 import type { Project } from '@/types/ProjectType';
+import { ProjectStatus } from '@/types/ProjectStatusType';
+import useToast from '@/hooks/useToast';
 
 type CreateModalTaskProps = {
   project: Project;
@@ -13,10 +16,23 @@ type CreateModalTaskProps = {
 };
 
 export default function CreateModalTask({ project, onClose: handleClose }: CreateModalTaskProps) {
-  // ToDo: 상태 생성을 위한 네트워크 로직 추가
-  const handleSubmit: SubmitHandler<TaskForm> = async (data) => {
-    console.log('생성 폼 제출');
-    console.log(data);
+  const { toastError } = useToast();
+  const { mutate: createTaskMutate } = useCreateStatusTask(project.projectId);
+  const { statusTaskList } = useReadStatusTasks(project.projectId);
+
+  const getLastSortOrder = (statusId: ProjectStatus['statusId']) => {
+    const statusTask = statusTaskList.find((statusTask) => statusTask.statusId === Number(statusId));
+    if (!statusTask) {
+      toastError('선택하신 프로젝트 상태는 존재하지 않습니다. ');
+      throw Error('프로젝트 상태가 존재하지 않습니다.');
+    }
+    return statusTask.tasks.length + 1;
+  };
+
+  // ToDo: 파일 생성 위한 네트워크 로직 추가
+  const handleSubmit: SubmitHandler<TaskForm> = async (taskFormData) => {
+    const sortOrder = getLastSortOrder(taskFormData.statusId);
+    createTaskMutate({ ...taskFormData, sortOrder });
     handleClose();
   };
   return (

--- a/src/components/modal/task/CreateModalTask.tsx
+++ b/src/components/modal/task/CreateModalTask.tsx
@@ -3,12 +3,12 @@ import ModalPortal from '@components/modal/ModalPortal';
 import ModalTaskForm from '@components/modal/task/ModalTaskForm';
 import ModalFormButton from '@components/modal/ModalFormButton';
 import { useCreateStatusTask, useReadStatusTasks } from '@hooks/query/useTaskQuery';
+import useToast from '@hooks/useToast';
 
 import type { SubmitHandler } from 'react-hook-form';
 import type { TaskForm } from '@/types/TaskType';
 import type { Project } from '@/types/ProjectType';
-import { ProjectStatus } from '@/types/ProjectStatusType';
-import useToast from '@/hooks/useToast';
+import type { ProjectStatus } from '@/types/ProjectStatusType';
 
 type CreateModalTaskProps = {
   project: Project;

--- a/src/components/modal/task/ModalTaskForm.tsx
+++ b/src/components/modal/task/ModalTaskForm.tsx
@@ -218,7 +218,12 @@ export default function ModalTaskForm({ formId, project, taskId, onSubmit }: Mod
           <input
             type="date"
             id="startDate"
-            {...register('startDate', TASK_VALIDATION_RULES.START_DATE(startDate, endDate))}
+            {...register('startDate', {
+              ...TASK_VALIDATION_RULES.START_DATE(startDate, endDate),
+              onChange: (e) => {
+                if (!hasDeadline) setValue('endDate', e.target.value);
+              },
+            })}
           />
           <div className={`my-5 h-10 grow text-xs text-error ${errors.startDate ? 'visible' : 'invisible'}`}>
             {errors.startDate?.message}

--- a/src/hooks/query/useTaskQuery.ts
+++ b/src/hooks/query/useTaskQuery.ts
@@ -1,8 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { findTaskList, updateTaskOrder } from '@services/taskService';
+import { createTask, findTaskList, updateTaskOrder } from '@services/taskService';
 import useToast from '@hooks/useToast';
 
-import type { TaskListWithStatus, TaskOrder } from '@/types/TaskType';
+import type { TaskForm, TaskListWithStatus, TaskOrder } from '@/types/TaskType';
 import type { Project } from '@/types/ProjectType';
 
 function getTaskNameList(taskList: TaskListWithStatus[]) {
@@ -14,7 +14,23 @@ function getTaskNameList(taskList: TaskListWithStatus[]) {
     : [];
 }
 
-// Todo: Task Query CUD로직 작성하기
+// Todo: Task Query UD로직 작성하기
+export function useCreateStatusTask(projectId: Project['projectId']) {
+  const { toastSuccess } = useToast();
+  const queryClient = useQueryClient();
+  const queryKey = ['projects', projectId, 'tasks'];
+
+  const mutation = useMutation({
+    mutationFn: (formData: TaskForm) => createTask(projectId, formData),
+    onSuccess: () => {
+      toastSuccess('프로젝트 일정을 등록하였습니다.');
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  return mutation;
+}
+
 export function useReadStatusTasks(projectId: Project['projectId']) {
   const {
     data: statusTaskList = [],

--- a/src/mocks/services/taskServiceHandler.ts
+++ b/src/mocks/services/taskServiceHandler.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from 'msw';
 import { STATUS_DUMMY, TASK_DUMMY } from '@mocks/mockData';
 import { getStatusHash, getTaskHash } from '@mocks/mockHash';
-import type { TaskOrderForm } from '@/types/TaskType';
+import type { TaskForm, TaskOrderForm } from '@/types/TaskType';
 
 const BASE_URL = import.meta.env.VITE_BASE_URL;
 
@@ -24,6 +24,22 @@ const taskServiceHandler = [
     });
 
     return HttpResponse.json(statusTaskList);
+  }),
+  // 일정 생성 API
+  http.post(`${BASE_URL}/project/:projectId/task`, async ({ request, params }) => {
+    const accessToken = request.headers.get('Authorization');
+    const formData = (await request.json()) as TaskForm;
+    const { projectId } = params;
+
+    if (!accessToken) return new HttpResponse(null, { status: 401 });
+
+    const statusList = STATUS_DUMMY.filter((status) => status.projectId === Number(projectId));
+    if (!statusList.find((status) => status.statusId === Number(formData.statusId))) {
+      return new HttpResponse(null, { status: 400 });
+    }
+
+    TASK_DUMMY.push({ ...formData, statusId: +formData.statusId, taskId: TASK_DUMMY.length + 1, files: [] });
+    return new HttpResponse(null, { status: 201 });
   }),
   // 일정 순서 변경 API
   http.patch(`${BASE_URL}/project/:projectId/task/order`, async ({ request, params }) => {

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -2,19 +2,32 @@ import { authAxios } from '@services/axiosProvider';
 
 import type { AxiosRequestConfig } from 'axios';
 import type { Project } from '@/types/ProjectType';
-import type { TaskListWithStatus, TaskOrderForm } from '@/types/TaskType';
+import type { TaskForm, TaskListWithStatus, TaskOrderForm } from '@/types/TaskType';
 
 /**
  * 프로젝트에 속한 모든 일정 목록 조회 API
  *
  * @export
  * @async
- * @param {Project['projectId']} projectId      - 대상 프로젝트 ID
+ * @param {Project['projectId']} projectId      - 프로젝트 ID
  * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
  * @returns {Promise<AxiosResponse<TaskListWithStatus[]>>}
  */
 export async function findTaskList(projectId: Project['projectId'], axiosConfig: AxiosRequestConfig = {}) {
   return authAxios.get<TaskListWithStatus[]>(`/project/${projectId}/task`, axiosConfig);
+}
+
+/**
+ * 일정 생성 API
+ *
+ * @export
+ * @param {Project['projectId']} projectId      - 프로젝트 ID
+ * @param {TaskForm} formData                   - 새로운 일정 정보 객체
+ * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
+ * @returns {Promise<AxiosResponse<void>>}
+ */
+export function createTask(projectId: Project['projectId'], formData: TaskForm, axiosConfig: AxiosRequestConfig = {}) {
+  return authAxios.post(`/project/${projectId}/task`, formData, axiosConfig);
 }
 
 /**


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] **\[Feat\]** 새로운 기능을 추가했어요.

## Related Issues
- close #114 

## What does this PR do?
- [x] 종료일 비활성화시 시작일 변경을 따라가도록 변경
- [x] 일정 생성 API  React Query 처리 추가
- [x] 일정 생성 API  MSW 처리 추가
- [x] 일정 생성 기능 구현

## Other information
프로젝트 상태 정보가 잘못오는 상황은 의도적으로 이상한 데이터를 끼워서 요청하거나, 잘못된  처리로 저장된 요염된 데이터인 경우일 것 같아요. 어떤 상황이든 좋은 상황은 아닌 것 같은데, 어떤 에러 처리를 추가해야할지 고민입니다. 다른 분들은 어떻게 생각하시나요?

```ts
 const getLastSortOrder = (statusId: ProjectStatus['statusId']) => {
    const statusTask = statusTaskList.find((statusTask) => statusTask.statusId === Number(statusId));
    if (!statusTask) {
      toastError('선택하신 프로젝트 상태는 존재하지 않습니다. ');
      throw Error('프로젝트 상태가 존재하지 않습니다.');
    }
    return statusTask.tasks.length + 1;
  };
```
## View
![화면 예시5](https://github.com/user-attachments/assets/9c77259f-db12-4b34-9e96-0eba3f7efc95)