### PR TITLE
Feat: #142 이메일 인증 기능 구현

### DIFF
--- a/src/components/user/auth-form/FooterLinks.tsx
+++ b/src/components/user/auth-form/FooterLinks.tsx
@@ -32,14 +32,14 @@ const links = {
 };
 
 export default function FooterLinks({ type }: FooterLinksProps) {
-  const nav = useNavigate();
+  const navigate = useNavigate();
 
   return (
     <>
       <div className="flex flex-row justify-center">
         {links[type].map((link, index) => (
           <div key={link.text} className="flex flex-row">
-            <button type="button" className="cursor-pointer bg-inherit font-bold" onClick={() => nav(link.path)}>
+            <button type="button" className="cursor-pointer bg-inherit font-bold" onClick={() => navigate(link.path)}>
               {link.text}
             </button>
             {index < links[type].length - 1 && <p className="mx-8">|</p>}
@@ -48,7 +48,7 @@ export default function FooterLinks({ type }: FooterLinksProps) {
       </div>
       <div className="mt-15 flex flex-row items-center justify-center gap-8">
         <p className="items-center font-bold">회원이 아니신가요?</p>
-        <button type="button" className="auth-btn" onClick={() => nav('/signup')}>
+        <button type="button" className="auth-btn" onClick={() => navigate('/signup')}>
           회원가입
         </button>
       </div>

--- a/src/components/user/auth-form/SearchDataForm.tsx
+++ b/src/components/user/auth-form/SearchDataForm.tsx
@@ -3,21 +3,28 @@ import ValidationInput from '@components/common/ValidationInput';
 import FooterLinks from '@components/user/auth-form/FooterLinks';
 import VerificationButton from '@components/user/auth-form/VerificationButton';
 import { USER_AUTH_VALIDATION_RULES } from '@constants/formValidationRules';
-import useEmailVerification from '@hooks/useEmailVerification';
 import { SearchPasswordForm } from '@/types/UserType';
 
 type SearchDataFormProps = {
   formType: 'searchId' | 'searchPassword';
+  isVerificationRequested: boolean;
+  requestVerificationCode: (email: string) => Promise<void>;
+  expireVerificationCode: () => void;
 };
 
-export default function SearchDataForm({ formType }: SearchDataFormProps) {
+export default function SearchDataForm({
+  formType,
+  isVerificationRequested,
+  requestVerificationCode,
+  expireVerificationCode,
+}: SearchDataFormProps) {
   const {
     register,
     handleSubmit,
     watch,
     formState: { errors, isSubmitting },
   } = useFormContext<SearchPasswordForm>();
-  const { isVerificationRequested, requestVerificationCode, expireVerificationCode } = useEmailVerification();
+
   return (
     <>
       {/* 아이디 */}
@@ -55,6 +62,7 @@ export default function SearchDataForm({ formType }: SearchDataFormProps) {
           buttonLabel={formType === 'searchId' ? '아이디 찾기' : '비밀번호 찾기'}
         />
       </div>
+
       <FooterLinks type={formType} />
     </>
   );

--- a/src/components/user/auth-form/SearchDataForm.tsx
+++ b/src/components/user/auth-form/SearchDataForm.tsx
@@ -14,6 +14,7 @@ export default function SearchDataForm({ formType }: SearchDataFormProps) {
   const {
     register,
     handleSubmit,
+    watch,
     formState: { errors, isSubmitting },
   } = useFormContext<SearchPasswordForm>();
   const { isVerificationRequested, requestVerificationCode, expireVerificationCode } = useEmailVerification();
@@ -49,7 +50,7 @@ export default function SearchDataForm({ formType }: SearchDataFormProps) {
         <VerificationButton
           isVerificationRequested={isVerificationRequested}
           isSubmitting={isSubmitting}
-          requestCode={handleSubmit(requestVerificationCode)}
+          requestCode={handleSubmit(() => requestVerificationCode(watch('email')))}
           expireVerificationCode={expireVerificationCode}
           buttonLabel={formType === 'searchId' ? '아이디 찾기' : '비밀번호 찾기'}
         />

--- a/src/components/user/auth-form/SearchDataForm.tsx
+++ b/src/components/user/auth-form/SearchDataForm.tsx
@@ -4,6 +4,7 @@ import FooterLinks from '@components/user/auth-form/FooterLinks';
 import VerificationButton from '@components/user/auth-form/VerificationButton';
 import { USER_AUTH_VALIDATION_RULES } from '@constants/formValidationRules';
 import useEmailVerification from '@hooks/useEmailVerification';
+import { SearchPasswordForm } from '@/types/UserType';
 
 type SearchDataFormProps = {
   formType: 'searchId' | 'searchPassword';
@@ -14,7 +15,7 @@ export default function SearchDataForm({ formType }: SearchDataFormProps) {
     register,
     handleSubmit,
     formState: { errors, isSubmitting },
-  } = useFormContext();
+  } = useFormContext<SearchPasswordForm>();
   const { isVerificationRequested, requestVerificationCode, expireVerificationCode } = useEmailVerification();
   return (
     <>
@@ -22,7 +23,7 @@ export default function SearchDataForm({ formType }: SearchDataFormProps) {
       {formType === 'searchPassword' && (
         <ValidationInput
           placeholder="아이디"
-          errors={errors.username?.message?.toString()}
+          errors={errors.username?.message}
           register={register('username', USER_AUTH_VALIDATION_RULES.ID)}
         />
       )}
@@ -30,7 +31,7 @@ export default function SearchDataForm({ formType }: SearchDataFormProps) {
       {/* 이메일 */}
       <ValidationInput
         placeholder="이메일"
-        errors={errors.email?.message?.toString()}
+        errors={errors.email?.message}
         register={register('email', USER_AUTH_VALIDATION_RULES.EMAIL)}
       />
 
@@ -38,7 +39,7 @@ export default function SearchDataForm({ formType }: SearchDataFormProps) {
       {isVerificationRequested && (
         <ValidationInput
           placeholder="인증번호"
-          errors={errors.code?.message?.toString()}
+          errors={errors.code?.message}
           register={register('code', USER_AUTH_VALIDATION_RULES.CERTIFICATION)}
         />
       )}

--- a/src/components/user/auth-form/SearchResultSection.tsx
+++ b/src/components/user/auth-form/SearchResultSection.tsx
@@ -6,7 +6,7 @@ type SearchResultSectionProps = {
 };
 
 export default function SearchResultSection({ label, result }: SearchResultSectionProps) {
-  const nav = useNavigate();
+  const navigate = useNavigate();
 
   return (
     <section className="space-y-20 text-center">
@@ -16,7 +16,7 @@ export default function SearchResultSection({ label, result }: SearchResultSecti
           <strong>{result}</strong>
         </p>
       </div>
-      <button type="button" className="auth-btn w-full" onClick={() => nav('/signin')}>
+      <button type="button" className="auth-btn w-full" onClick={() => navigate('/signin')}>
         로그인으로 돌아가기
       </button>
     </section>

--- a/src/hooks/useEmailVerification.ts
+++ b/src/hooks/useEmailVerification.ts
@@ -1,7 +1,7 @@
-import { useState } from 'react';
-import useToast from '@hooks/useToast';
+import { useEffect, useState } from 'react';
 import { AxiosError } from 'axios';
-import { sendEmailCode } from '@/services/authService';
+import { sendEmailCode } from '@services/authService';
+import useToast from '@hooks/useToast';
 
 export default function useEmailVerification() {
   const [isVerificationRequested, setIsVerificationRequested] = useState(false);
@@ -29,6 +29,16 @@ export default function useEmailVerification() {
     setIsVerificationRequested(false);
     toastError('인증 시간이 만료되었습니다. 다시 시도해 주세요.');
   };
+
+  // 상태가 잘못 변경되는지 감지하기 위한 useEffect
+  useEffect(() => {
+    if (isVerificationRequested) {
+      // 상태가 true일 때만 인증 필드가 유지되도록 함
+      console.log('인증 요청 상태: true');
+    } else {
+      console.log('인증 요청 상태: false');
+    }
+  }, [isVerificationRequested]);
 
   return {
     isVerificationRequested,

--- a/src/hooks/useEmailVerification.ts
+++ b/src/hooks/useEmailVerification.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { AxiosError } from 'axios';
 import { sendEmailCode } from '@services/authService';
 import useToast from '@hooks/useToast';
@@ -29,16 +29,6 @@ export default function useEmailVerification() {
     setIsVerificationRequested(false);
     toastError('인증 시간이 만료되었습니다. 다시 시도해 주세요.');
   };
-
-  // 상태가 잘못 변경되는지 감지하기 위한 useEffect
-  useEffect(() => {
-    if (isVerificationRequested) {
-      // 상태가 true일 때만 인증 필드가 유지되도록 함
-      console.log('인증 요청 상태: true');
-    } else {
-      console.log('인증 요청 상태: false');
-    }
-  }, [isVerificationRequested]);
 
   return {
     isVerificationRequested,

--- a/src/hooks/useEmailVerification.ts
+++ b/src/hooks/useEmailVerification.ts
@@ -1,32 +1,27 @@
 import { useState } from 'react';
-import { UseFormSetError } from 'react-hook-form';
 import useToast from '@hooks/useToast';
-import type { UserSignUpForm } from '@/types/UserType';
+import { AxiosError } from 'axios';
+import { sendEmailCode } from '@/services/authService';
 
 export default function useEmailVerification() {
   const [isVerificationRequested, setIsVerificationRequested] = useState(false);
   const { toastSuccess, toastError } = useToast();
 
   // 이메일 인증번호 요청 함수
-  const requestVerificationCode = () => {
-    if (!isVerificationRequested) {
+  const requestVerificationCode = async (email: string) => {
+    if (isVerificationRequested) return;
+
+    try {
+      await sendEmailCode({ email });
       setIsVerificationRequested(true);
       toastSuccess('인증번호가 발송되었습니다. 이메일을 확인해 주세요.');
+    } catch (error) {
+      if (error instanceof AxiosError && error.response) {
+        toastError(error.response.data.message);
+      } else {
+        toastError('예상치 못한 에러가 발생했습니다.');
+      }
     }
-  };
-
-  // 인증번호 확인 함수
-  const verifyCode = (verificationCode: string, setError: UseFormSetError<UserSignUpForm>) => {
-    // ToDo: 이메일 인증 API 추가
-    if (verificationCode === '1234') return true;
-
-    // 인증번호 불일치
-    setError('code', {
-      type: 'manual',
-      message: '인증번호가 일치하지 않습니다.',
-    });
-    toastError('인증번호가 유효하지 않습니다. 다시 시도해 주세요.');
-    return false;
   };
 
   // 인증 코드 만료
@@ -38,7 +33,6 @@ export default function useEmailVerification() {
   return {
     isVerificationRequested,
     requestVerificationCode,
-    verifyCode,
     expireVerificationCode,
   };
 }

--- a/src/mocks/mockData.ts
+++ b/src/mocks/mockData.ts
@@ -34,6 +34,8 @@ type TaskFile = {
 
 export const JWT_TOKEN_DUMMY = 'mocked-header.mocked-payload-4.mocked-signature';
 
+export const emailVerificationCode = '1234';
+
 export const USER_INFO_DUMMY = {
   provider: 'LOCAL',
   userId: 1,

--- a/src/mocks/services/authServiceHandler.ts
+++ b/src/mocks/services/authServiceHandler.ts
@@ -1,12 +1,11 @@
 import Cookies from 'js-cookie';
 import { http, HttpResponse } from 'msw';
 import { AUTH_SETTINGS } from '@constants/settings';
-import { USER_INFO_DUMMY } from '@mocks/mockData';
+import { emailVerificationCode, USER_INFO_DUMMY } from '@mocks/mockData';
 import { EmailVerificationForm, RequestEmailCode, SearchPasswordForm, UserSignInForm } from '@/types/UserType';
 
 const BASE_URL = import.meta.env.VITE_BASE_URL;
 const refreshTokenExpiryDate = new Date(Date.now() + AUTH_SETTINGS.REFRESH_TOKEN_EXPIRATION).toISOString();
-let verificationCode = '0000';
 
 const authServiceHandler = [
   // 로그인 API
@@ -121,9 +120,6 @@ const authServiceHandler = [
       return HttpResponse.json({ message: '이메일을 다시 확인해 주세요.' }, { status: 400 });
     }
 
-    verificationCode = Math.floor(1000 + Math.random() * 9000).toString();
-    console.log(verificationCode);
-
     return HttpResponse.json(null, { status: 200 });
   }),
 
@@ -131,7 +127,7 @@ const authServiceHandler = [
   http.post(`${BASE_URL}/user/recover/username`, async ({ request }) => {
     const { email, code } = (await request.json()) as EmailVerificationForm;
 
-    if (code !== verificationCode) {
+    if (code !== emailVerificationCode) {
       return HttpResponse.json(
         { message: '이메일 인증 번호가 일치하지 않습니다. 다시 확인해 주세요.' },
         { status: 401 },
@@ -151,7 +147,7 @@ const authServiceHandler = [
 
     const tempPassword = '!1p2l3nqlz';
 
-    if (code !== verificationCode) {
+    if (code !== emailVerificationCode) {
       return HttpResponse.json(
         { message: '이메일 인증 번호가 일치하지 않습니다. 다시 확인해 주세요.' },
         { status: 401 },

--- a/src/mocks/services/authServiceHandler.ts
+++ b/src/mocks/services/authServiceHandler.ts
@@ -116,9 +116,8 @@ const authServiceHandler = [
   http.post(`${BASE_URL}/user/verify/send`, async ({ request }) => {
     const { email } = (await request.json()) as RequestEmailCode;
 
-    if (email !== USER_INFO_DUMMY.email) {
+    if (email !== USER_INFO_DUMMY.email)
       return HttpResponse.json({ message: '이메일을 다시 확인해 주세요.' }, { status: 400 });
-    }
 
     return HttpResponse.json(null, { status: 200 });
   }),
@@ -134,9 +133,8 @@ const authServiceHandler = [
       );
     }
 
-    if (email !== USER_INFO_DUMMY.email) {
+    if (email !== USER_INFO_DUMMY.email)
       return HttpResponse.json({ message: '이메일을 다시 확인해 주세요.' }, { status: 400 });
-    }
 
     return HttpResponse.json({ username: USER_INFO_DUMMY.username }, { status: 200 });
   }),

--- a/src/pages/setting/UserAuthenticatePage.tsx
+++ b/src/pages/setting/UserAuthenticatePage.tsx
@@ -6,13 +6,11 @@ import VerificationButton from '@components/user/auth-form/VerificationButton';
 import { EmailVerificationForm } from '@/types/UserType';
 
 function UserAuthenticatePage() {
-  const { isVerificationRequested, requestVerificationCode, verifyCode, expireVerificationCode } =
-    useEmailVerification();
+  const { isVerificationRequested, requestVerificationCode, expireVerificationCode } = useEmailVerification();
 
   const {
     register,
     handleSubmit,
-    setError,
     formState: { errors, isSubmitting },
     watch,
   } = useForm<EmailVerificationForm>({
@@ -20,9 +18,6 @@ function UserAuthenticatePage() {
   });
 
   const onSubmit = async (data: EmailVerificationForm) => {
-    const verifyResult = verifyCode(watch('code'), setError);
-    if (!verifyResult) return;
-
     // TODO: 인증 성공 후 전역 상태관리 및 리다이렉트 로직 작성
     console.log(data);
   };
@@ -56,7 +51,7 @@ function UserAuthenticatePage() {
           <VerificationButton
             isVerificationRequested={isVerificationRequested}
             isSubmitting={isSubmitting}
-            requestCode={handleSubmit(requestVerificationCode)}
+            requestCode={handleSubmit(() => requestVerificationCode(watch('email')))}
             expireVerificationCode={expireVerificationCode}
             buttonLabel="확인"
           />

--- a/src/pages/user/SearchIdPage.tsx
+++ b/src/pages/user/SearchIdPage.tsx
@@ -25,6 +25,16 @@ export default function SearchIdPage() {
   const { handleSubmit, setError, setValue } = methods;
   const { isVerificationRequested, requestVerificationCode, expireVerificationCode } = useEmailVerification();
 
+  // ToDo: useAxios 훅 적용 후 해당 함수 수정 및 삭제하기
+  const handleVerificationError = () => {
+    setError('code', {
+      type: 'manual',
+      message: '인증번호가 일치하지 않습니다.',
+    });
+    setValue('code', '');
+  };
+
+  // ToDo: useAxios 훅을 이용한 네트워크 로직으로 변경
   const onSubmit = async (data: EmailVerificationForm) => {
     setLoading(true);
     try {
@@ -33,13 +43,7 @@ export default function SearchIdPage() {
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
         toastError(error.response.data.message);
-        if (error.response.status === 401) {
-          setError('code', {
-            type: 'manual',
-            message: '인증번호가 일치하지 않습니다.',
-          });
-          setValue('code', '');
-        }
+        if (error.response.status === 401) handleVerificationError();
       } else {
         toastError('예상치 못한 에러가 발생했습니다.');
       }

--- a/src/pages/user/SearchIdPage.tsx
+++ b/src/pages/user/SearchIdPage.tsx
@@ -42,8 +42,8 @@ export default function SearchIdPage() {
       setSearchIdResult(fetchData.data.username);
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
-        toastError(error.response.data.message);
         if (error.response.status === 401) handleVerificationError();
+        else toastError(error.response.data.message);
       } else {
         toastError('예상치 못한 에러가 발생했습니다.');
       }

--- a/src/pages/user/SearchIdPage.tsx
+++ b/src/pages/user/SearchIdPage.tsx
@@ -4,7 +4,6 @@ import { useForm, FormProvider } from 'react-hook-form';
 import Spinner from '@components/common/Spinner';
 import SearchResultSection from '@components/user/auth-form/SearchResultSection';
 import SearchDataForm from '@components/user/auth-form/SearchDataForm';
-import useEmailVerification from '@hooks/useEmailVerification';
 import useToast from '@hooks/useToast';
 import AuthFormLayout from '@layouts/AuthFormLayout';
 import { searchUserId } from '@services/authService';
@@ -12,7 +11,6 @@ import { generateSecureUserId } from '@utils/converter';
 import { EmailVerificationForm } from '@/types/UserType';
 
 export default function SearchIdPage() {
-  const { verifyCode } = useEmailVerification();
   const [searchIdResult, setSearchIdResult] = useState<null | string>(null);
   const [loading, setLoading] = useState(false);
   const { toastError } = useToast();
@@ -23,13 +21,10 @@ export default function SearchIdPage() {
       code: '',
     },
   });
-  const { watch, handleSubmit, setError } = methods;
+  const { handleSubmit, setError, setValue } = methods;
 
   // ToDo: useAxios 훅을 이용한 네트워크 로직으로 변경
   const onSubmit = async (data: EmailVerificationForm) => {
-    const verifyResult = verifyCode(watch('code'), setError);
-    if (!verifyResult) return;
-
     setLoading(true);
     try {
       const fetchData = await searchUserId(data);
@@ -37,6 +32,13 @@ export default function SearchIdPage() {
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
         toastError(error.response.data.message);
+        if (error.response.status === 401) {
+          setError('code', {
+            type: 'manual',
+            message: '인증번호가 일치하지 않습니다.',
+          });
+          setValue('code', '');
+        }
       } else {
         toastError('예상치 못한 에러가 발생했습니다.');
       }

--- a/src/pages/user/SearchIdPage.tsx
+++ b/src/pages/user/SearchIdPage.tsx
@@ -14,6 +14,7 @@ import { EmailVerificationForm } from '@/types/UserType';
 export default function SearchIdPage() {
   const [searchIdResult, setSearchIdResult] = useState<null | string>(null);
   const [loading, setLoading] = useState(false);
+  const { isVerificationRequested, requestVerificationCode, expireVerificationCode } = useEmailVerification();
   const { toastError } = useToast();
   const methods = useForm<EmailVerificationForm>({
     mode: 'onChange',
@@ -23,7 +24,12 @@ export default function SearchIdPage() {
     },
   });
   const { handleSubmit, setError, setValue } = methods;
-  const { isVerificationRequested, requestVerificationCode, expireVerificationCode } = useEmailVerification();
+
+  const emailVerificationProps = {
+    isVerificationRequested,
+    requestVerificationCode,
+    expireVerificationCode,
+  };
 
   // ToDo: useAxios 훅 적용 후 해당 함수 수정 및 삭제하기
   const handleVerificationError = () => {
@@ -61,14 +67,7 @@ export default function SearchIdPage() {
           <SearchResultSection label="아이디" result={generateSecureUserId(searchIdResult)} />
         )}
 
-        {!loading && !searchIdResult && (
-          <SearchDataForm
-            formType="searchId"
-            isVerificationRequested={isVerificationRequested}
-            requestVerificationCode={requestVerificationCode}
-            expireVerificationCode={expireVerificationCode}
-          />
-        )}
+        {!loading && !searchIdResult && <SearchDataForm formType="searchId" {...emailVerificationProps} />}
       </AuthFormLayout>
     </FormProvider>
   );

--- a/src/pages/user/SearchIdPage.tsx
+++ b/src/pages/user/SearchIdPage.tsx
@@ -8,6 +8,7 @@ import useToast from '@hooks/useToast';
 import AuthFormLayout from '@layouts/AuthFormLayout';
 import { searchUserId } from '@services/authService';
 import { generateSecureUserId } from '@utils/converter';
+import useEmailVerification from '@hooks/useEmailVerification';
 import { EmailVerificationForm } from '@/types/UserType';
 
 export default function SearchIdPage() {
@@ -22,8 +23,8 @@ export default function SearchIdPage() {
     },
   });
   const { handleSubmit, setError, setValue } = methods;
+  const { isVerificationRequested, requestVerificationCode, expireVerificationCode } = useEmailVerification();
 
-  // ToDo: useAxios 훅을 이용한 네트워크 로직으로 변경
   const onSubmit = async (data: EmailVerificationForm) => {
     setLoading(true);
     try {
@@ -56,7 +57,14 @@ export default function SearchIdPage() {
           <SearchResultSection label="아이디" result={generateSecureUserId(searchIdResult)} />
         )}
 
-        {!loading && !searchIdResult && <SearchDataForm formType="searchId" />}
+        {!loading && !searchIdResult && (
+          <SearchDataForm
+            formType="searchId"
+            isVerificationRequested={isVerificationRequested}
+            requestVerificationCode={requestVerificationCode}
+            expireVerificationCode={expireVerificationCode}
+          />
+        )}
       </AuthFormLayout>
     </FormProvider>
   );

--- a/src/pages/user/SearchPasswordPage.tsx
+++ b/src/pages/user/SearchPasswordPage.tsx
@@ -25,6 +25,15 @@ export default function SearchPasswordPage() {
   });
   const { handleSubmit, setError, setValue } = methods;
 
+  // ToDo: useAxios 훅 적용 후 해당 함수 수정 및 삭제하기
+  const handleVerificationError = () => {
+    setError('code', {
+      type: 'manual',
+      message: '인증번호가 일치하지 않습니다.',
+    });
+    setValue('code', '');
+  };
+
   // ToDo: useAxios 훅을 이용한 네트워크 로직으로 변경
   const onSubmit = async (data: SearchPasswordForm) => {
     setLoading(true);
@@ -34,13 +43,7 @@ export default function SearchPasswordPage() {
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
         toastError(error.response.data.message);
-        if (error.response.status === 401) {
-          setError('code', {
-            type: 'manual',
-            message: '인증번호가 일치하지 않습니다.',
-          });
-          setValue('code', '');
-        }
+        if (error.response.status === 401) handleVerificationError();
       } else {
         toastError('예상치 못한 에러가 발생했습니다.');
       }

--- a/src/pages/user/SearchPasswordPage.tsx
+++ b/src/pages/user/SearchPasswordPage.tsx
@@ -25,6 +25,12 @@ export default function SearchPasswordPage() {
   });
   const { handleSubmit, setError, setValue } = methods;
 
+  const emailVerificationProps = {
+    isVerificationRequested,
+    requestVerificationCode,
+    expireVerificationCode,
+  };
+
   // ToDo: useAxios 훅 적용 후 해당 함수 수정 및 삭제하기
   const handleVerificationError = () => {
     setError('code', {
@@ -42,8 +48,8 @@ export default function SearchPasswordPage() {
       setTempPassword(fetchData.data.password);
     } catch (error) {
       if (error instanceof AxiosError && error.response) {
-        toastError(error.response.data.message);
         if (error.response.status === 401) handleVerificationError();
+        else toastError(error.response.data.message);
       } else {
         toastError('예상치 못한 에러가 발생했습니다.');
       }
@@ -59,14 +65,7 @@ export default function SearchPasswordPage() {
 
         {!loading && tempPassword && <SearchResultSection label="임시 비밀번호" result={tempPassword} />}
 
-        {!loading && !tempPassword && (
-          <SearchDataForm
-            formType="searchPassword"
-            isVerificationRequested={isVerificationRequested}
-            requestVerificationCode={requestVerificationCode}
-            expireVerificationCode={expireVerificationCode}
-          />
-        )}
+        {!loading && !tempPassword && <SearchDataForm formType="searchPassword" {...emailVerificationProps} />}
       </AuthFormLayout>
     </FormProvider>
   );

--- a/src/pages/user/SearchPasswordPage.tsx
+++ b/src/pages/user/SearchPasswordPage.tsx
@@ -7,11 +7,13 @@ import SearchDataForm from '@components/user/auth-form/SearchDataForm';
 import AuthFormLayout from '@layouts/AuthFormLayout';
 import { searchUserPassword } from '@services/authService';
 import useToast from '@hooks/useToast';
+import useEmailVerification from '@hooks/useEmailVerification';
 import type { SearchPasswordForm } from '@/types/UserType';
 
 export default function SearchPasswordPage() {
   const [tempPassword, setTempPassword] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const { isVerificationRequested, requestVerificationCode, expireVerificationCode } = useEmailVerification();
   const { toastError } = useToast();
   const methods = useForm<SearchPasswordForm>({
     mode: 'onChange',
@@ -54,7 +56,14 @@ export default function SearchPasswordPage() {
 
         {!loading && tempPassword && <SearchResultSection label="임시 비밀번호" result={tempPassword} />}
 
-        {!loading && !tempPassword && <SearchDataForm formType="searchPassword" />}
+        {!loading && !tempPassword && (
+          <SearchDataForm
+            formType="searchPassword"
+            isVerificationRequested={isVerificationRequested}
+            requestVerificationCode={requestVerificationCode}
+            expireVerificationCode={expireVerificationCode}
+          />
+        )}
       </AuthFormLayout>
     </FormProvider>
   );

--- a/src/pages/user/SignUpPage.tsx
+++ b/src/pages/user/SignUpPage.tsx
@@ -13,8 +13,7 @@ import type { UserSignUpForm } from '@/types/UserType';
 
 export default function SignUpPage() {
   const { toastSuccess, toastError } = useToast();
-  const { isVerificationRequested, requestVerificationCode, verifyCode, expireVerificationCode } =
-    useEmailVerification();
+  const { isVerificationRequested, requestVerificationCode, expireVerificationCode } = useEmailVerification();
 
   const methods = useForm<UserSignUpForm>({
     mode: 'onChange',
@@ -35,10 +34,6 @@ export default function SignUpPage() {
   const onSubmit = async (data: UserSignUpForm) => {
     const { username, code, checkPassword, profileImageName, ...filteredData } = data;
     console.log(data);
-
-    const verifyResult = verifyCode(methods.watch('code'), methods.setError);
-    if (!verifyResult) return;
-
     // TODO: 폼 제출 로직 수정 필요
     try {
       // 회원가입 폼
@@ -152,7 +147,7 @@ export default function SignUpPage() {
           <VerificationButton
             isVerificationRequested={isVerificationRequested}
             isSubmitting={methods.formState.isSubmitting}
-            requestCode={methods.handleSubmit(requestVerificationCode)}
+            requestCode={methods.handleSubmit(() => requestVerificationCode(methods.watch('email')))}
             expireVerificationCode={expireVerificationCode}
             buttonLabel="회원가입"
           />

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -3,6 +3,7 @@ import { authAxios, defaultAxios } from '@services/axiosProvider';
 import type { AxiosRequestConfig } from 'axios';
 import type {
   EmailVerificationForm,
+  RequestEmailCode,
   SearchIdResult,
   SearchPasswordForm,
   SearchPasswordResult,
@@ -69,6 +70,19 @@ export async function logout(axiosConfig: AxiosRequestConfig = {}) {
  */
 export async function postTest(axiosConfig: AxiosRequestConfig = {}) {
   return authAxios.post('test', null, axiosConfig);
+}
+
+/**
+ * 이메일 인증 API
+ *
+ * @export
+ * @async
+ * @param {RequestEmailCode} email - 이메일
+ * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
+ * @returns {Promise<AxiosResponse>}
+ */
+export async function sendEmailCode(email: RequestEmailCode, axiosConfig: AxiosRequestConfig = {}) {
+  return authAxios.post('user/verify/send', email, axiosConfig);
 }
 
 /**

--- a/src/types/UserType.tsx
+++ b/src/types/UserType.tsx
@@ -40,3 +40,5 @@ export type SearchIdResult = Pick<User, 'username'>;
 export type SearchPasswordResult = {
   password: string;
 };
+
+export type RequestEmailCode = Pick<User, 'email'>;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해 주세요. -->

- [x] **\[Feat\]** 새로운 기능을 추가했어요.

## Related Issues

<!--#을 눌러 이슈와 연결해 주세요-->
#142 이메일 인증 기능 구현

## What does this PR do?

<!--무엇을 하셨나요?-->
- [x] 이메일 인증 네트워크 로직 작성
- [x] 이메일 인증 연결
    - [x] ID 찾기
    - [x] PW 찾기
- [x] MSW의 하드코딩된 이메일 인증 번호를 mockData에서 import 해오는 방식으로 변경
- [x] 테스트

## View
![이메일 인증 구현](https://github.com/user-attachments/assets/dc6a8f9b-7597-4ee6-83c1-3e9650d1bc22)

## Other information

<!--참고한 자료, 추가적인 사항, 기타 의견-->
- 이메일 인증 코드의 일치 여부는 ID, PW 찾기 API 내부에서 확인되는 방식입니다. 인증번호가 일치하지 않을 시 서버에서는 401 에러를 반환합니다. 
- 401 에러 반환 시 유저에게 에러 발생 사실을 알려주어야 했기에, `handleVerificationError` 함수를 실행하도록 처리했습니다. 이 처리 때문에 현재 네트워크 코드가 지저분해 보이는데, `useAxios` 적용되면 수정 및 리팩토링하도록 하겠습니다.
-  `회원가입`, `비밀번호 변경 전 인증` 페이지의 이메일 인증은 해당 API를 작성하면서 적용하도록 하겠습니다!
- 추가: 에러 발생을 명시할 때, 토스트 + 입력 필드 setError 두 가지를 사용하고 있는데, 너무 번잡하다면 AI 리뷰대로 둘 중 하나를 삭제해도 좋을 것 같습니다. 다른 분들의 의견은 어떤지 궁금합니다🧐