### PR TITLE
Feat: #146 비밀번호 변경 전 인증 페이지의 인증 로직 구현

### DIFF
--- a/src/components/user/auth-form/SearchDataForm.tsx
+++ b/src/components/user/auth-form/SearchDataForm.tsx
@@ -47,8 +47,8 @@ export default function SearchDataForm({
       {isVerificationRequested && (
         <ValidationInput
           placeholder="인증번호"
-          errors={errors.code?.message}
-          register={register('code', USER_AUTH_VALIDATION_RULES.CERTIFICATION)}
+          errors={errors.verificationCode?.message}
+          register={register('verificationCode', USER_AUTH_VALIDATION_RULES.VERIFICATION_CODE)}
         />
       )}
 

--- a/src/constants/formValidationRules.ts
+++ b/src/constants/formValidationRules.ts
@@ -69,7 +69,7 @@ export const USER_AUTH_VALIDATION_RULES = deepFreeze({
       message: '이메일 형식에 맞지 않습니다.',
     },
   },
-  CERTIFICATION: { required: '인증번호를 입력해 주세요.' },
+  VERIFICATION_CODE: { required: '인증번호를 입력해 주세요.' },
   NICKNAME: {
     required: '닉네임을 입력해 주세요.',
     minLength: {

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -4,6 +4,7 @@ export const AUTH_SETTINGS = Object.freeze({
   // ACCESS_TOKEN_EXPIRATION: 5 * SECOND, // 테스트용 5초
   ACCESS_TOKEN_EXPIRATION: 15 * MINUTE, // 15분
   REFRESH_TOKEN_EXPIRATION: 7 * DAY, // 7일
+  VERIFIED_EXPIRATION: 15 * MINUTE,
 });
 
 export const USER_SETTINGS = Object.freeze({

--- a/src/mocks/mockData.ts
+++ b/src/mocks/mockData.ts
@@ -34,7 +34,7 @@ type TaskFile = {
 
 export const JWT_TOKEN_DUMMY = 'mocked-header.mocked-payload-4.mocked-signature';
 
-export const emailVerificationCode = '1234';
+export const VERIFICATION_CODE_DUMMY = '1234';
 
 export const USER_INFO_DUMMY = {
   provider: 'LOCAL',

--- a/src/mocks/services/authServiceHandler.ts
+++ b/src/mocks/services/authServiceHandler.ts
@@ -18,7 +18,7 @@ const authServiceHandler = [
   http.post(`${BASE_URL}/user/login`, async ({ request }) => {
     const { username, password } = (await request.json()) as UserSignInForm;
 
-    if (username === 'test' && password === 'test@123') {
+    if (username === USER_INFO_DUMMY.username && password === USER_INFO_DUMMY.password) {
       const accessToken = 'mockedAccessToken';
       const refreshToken = 'mockedRefreshToken';
 
@@ -118,12 +118,22 @@ const authServiceHandler = [
     return new HttpResponse(null, { status: 401 });
   }),
 
-  // 이메일 인증 API
+  // 이메일 인증 번호 요청 API
   http.post(`${BASE_URL}/user/verify/send`, async ({ request }) => {
     const { email } = (await request.json()) as RequestEmailCode;
 
     if (email !== USER_INFO_DUMMY.email)
       return HttpResponse.json({ message: '이메일을 다시 확인해 주세요.' }, { status: 400 });
+
+    return HttpResponse.json(null, { status: 200 });
+  }),
+
+  // 이메일 인증 번호 확인 API
+  http.post(`${BASE_URL}/user/verify/code`, async ({ request }) => {
+    const { email, code } = (await request.json()) as EmailVerificationForm;
+
+    if (email !== USER_INFO_DUMMY.email || code !== emailVerificationCode)
+      return HttpResponse.json({ message: '인증번호가 일치하지 않습니다.' }, { status: 401 });
 
     return HttpResponse.json(null, { status: 200 });
   }),

--- a/src/mocks/services/authServiceHandler.ts
+++ b/src/mocks/services/authServiceHandler.ts
@@ -1,7 +1,7 @@
 import Cookies from 'js-cookie';
 import { http, HttpResponse } from 'msw';
 import { AUTH_SETTINGS } from '@constants/settings';
-import { emailVerificationCode, USER_INFO_DUMMY } from '@mocks/mockData';
+import { VERIFICATION_CODE_DUMMY, USER_INFO_DUMMY } from '@mocks/mockData';
 import {
   EmailVerificationForm,
   RequestEmailCode,
@@ -130,9 +130,9 @@ const authServiceHandler = [
 
   // 이메일 인증 번호 확인 API
   http.post(`${BASE_URL}/user/verify/code`, async ({ request }) => {
-    const { email, code } = (await request.json()) as EmailVerificationForm;
+    const { email, verificationCode } = (await request.json()) as EmailVerificationForm;
 
-    if (email !== USER_INFO_DUMMY.email || code !== emailVerificationCode)
+    if (email !== USER_INFO_DUMMY.email || verificationCode !== VERIFICATION_CODE_DUMMY)
       return HttpResponse.json({ message: '인증번호가 일치하지 않습니다.' }, { status: 401 });
 
     return HttpResponse.json(null, { status: 200 });
@@ -140,9 +140,9 @@ const authServiceHandler = [
 
   // 아이디 찾기 API
   http.post(`${BASE_URL}/user/recover/username`, async ({ request }) => {
-    const { email, code } = (await request.json()) as EmailVerificationForm;
+    const { email, verificationCode } = (await request.json()) as EmailVerificationForm;
 
-    if (code !== emailVerificationCode) {
+    if (verificationCode !== VERIFICATION_CODE_DUMMY) {
       return HttpResponse.json(
         { message: '이메일 인증 번호가 일치하지 않습니다. 다시 확인해 주세요.' },
         { status: 401 },
@@ -157,11 +157,11 @@ const authServiceHandler = [
 
   // 비밀번호 찾기 API
   http.post(`${BASE_URL}/user/recover/password`, async ({ request }) => {
-    const { username, email, code } = (await request.json()) as SearchPasswordForm;
+    const { username, email, verificationCode } = (await request.json()) as SearchPasswordForm;
 
     const tempPassword = '!1p2l3nqlz';
 
-    if (code !== emailVerificationCode) {
+    if (verificationCode !== VERIFICATION_CODE_DUMMY) {
       return HttpResponse.json(
         { message: '이메일 인증 번호가 일치하지 않습니다. 다시 확인해 주세요.' },
         { status: 401 },

--- a/src/pages/setting/UserAuthenticatePage.tsx
+++ b/src/pages/setting/UserAuthenticatePage.tsx
@@ -59,8 +59,8 @@ function UserAuthenticatePage() {
           {isVerificationRequested && (
             <ValidationInput
               label="인증번호"
-              errors={errors.code?.message}
-              register={register('code', USER_AUTH_VALIDATION_RULES.CERTIFICATION)}
+              errors={errors.verificationCode?.message}
+              register={register('verificationCode', USER_AUTH_VALIDATION_RULES.CERTIFICATION)}
             />
           )}
 

--- a/src/pages/setting/UserAuthenticatePage.tsx
+++ b/src/pages/setting/UserAuthenticatePage.tsx
@@ -26,6 +26,7 @@ function UserAuthenticatePage() {
   });
 
   const onSubmit = async (data: EmailVerificationForm) => {
+    // ToDo: useAxios 훅을 이용한 네트워크 로직으로 변경
     try {
       await checkEmailCode(data);
       onVerifyCode();

--- a/src/pages/setting/UserAuthenticatePage.tsx
+++ b/src/pages/setting/UserAuthenticatePage.tsx
@@ -60,7 +60,7 @@ function UserAuthenticatePage() {
             <ValidationInput
               label="인증번호"
               errors={errors.verificationCode?.message}
-              register={register('verificationCode', USER_AUTH_VALIDATION_RULES.CERTIFICATION)}
+              register={register('verificationCode', USER_AUTH_VALIDATION_RULES.VERIFICATION_CODE)}
             />
           )}
 

--- a/src/pages/setting/UserAuthenticatePage.tsx
+++ b/src/pages/setting/UserAuthenticatePage.tsx
@@ -31,11 +31,8 @@ function UserAuthenticatePage() {
       onVerifyCode();
       navigate('/setting/password', { replace: true });
     } catch (error) {
-      if (error instanceof AxiosError && error.response) {
-        if (error.response.status === 401) toastError(error.response.data.message);
-      } else {
-        toastError('예상치 못한 에러가 발생했습니다.');
-      }
+      if (error instanceof AxiosError && error.response) toastError(error.response.data.message);
+      else toastError('예상치 못한 에러가 발생했습니다.');
     }
   };
 

--- a/src/pages/setting/UserPasswordSettingPage.tsx
+++ b/src/pages/setting/UserPasswordSettingPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+// import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AxiosError } from 'axios';
 import { useForm } from 'react-hook-form';
@@ -6,11 +6,11 @@ import ValidationInput from '@components/common/ValidationInput';
 import { USER_AUTH_VALIDATION_RULES } from '@constants/formValidationRules';
 import useToast from '@hooks/useToast';
 import { updateUserPassword } from '@services/authService';
-import { useStore } from '@stores/useStore';
+// import { useStore } from '@stores/useStore';
 import { UpdatePasswordForm } from '@/types/UserType';
 
 export default function UserPasswordSettingPage() {
-  const { isVerified } = useStore();
+  // const { isVerified } = useStore();
   const navigate = useNavigate();
   const { toastSuccess, toastError } = useToast();
   const {
@@ -22,9 +22,10 @@ export default function UserPasswordSettingPage() {
     mode: 'onChange',
   });
 
-  useEffect(() => {
-    if (!isVerified) navigate('/setting/auth', { replace: true });
-  }, [isVerified]);
+  // ToDo: 이메일 인증 API가 확정된 후 활성화
+  // useEffect(() => {
+  //   if (!isVerified) navigate('/setting/auth', { replace: true });
+  // }, []);
 
   const onSubmit = async (data: UpdatePasswordForm) => {
     const { checkNewPassword, ...submitData } = data;

--- a/src/pages/setting/UserPasswordSettingPage.tsx
+++ b/src/pages/setting/UserPasswordSettingPage.tsx
@@ -5,9 +5,12 @@ import { USER_AUTH_VALIDATION_RULES } from '@constants/formValidationRules';
 import { updateUserPassword } from '@services/authService';
 import useToast from '@hooks/useToast';
 import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
 import { UpdatePasswordForm } from '@/types/UserType';
+import useStore from '@/stores/useStore';
 
 export default function UserPasswordSettingPage() {
+  const isVerified = useStore((state) => state.isVerified);
   const navigate = useNavigate();
   const { toastSuccess, toastError } = useToast();
   const {
@@ -18,6 +21,10 @@ export default function UserPasswordSettingPage() {
   } = useForm<UpdatePasswordForm>({
     mode: 'onChange',
   });
+
+  useEffect(() => {
+    if (!isVerified) navigate('/setting/auth', { replace: true });
+  }, [isVerified]);
 
   const onSubmit = async (data: UpdatePasswordForm) => {
     const { checkNewPassword, ...submitData } = data;

--- a/src/pages/setting/UserPasswordSettingPage.tsx
+++ b/src/pages/setting/UserPasswordSettingPage.tsx
@@ -1,16 +1,16 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { AxiosError } from 'axios';
 import { useForm } from 'react-hook-form';
 import ValidationInput from '@components/common/ValidationInput';
 import { USER_AUTH_VALIDATION_RULES } from '@constants/formValidationRules';
-import { updateUserPassword } from '@services/authService';
 import useToast from '@hooks/useToast';
-import { useNavigate } from 'react-router-dom';
-import { useEffect } from 'react';
+import { updateUserPassword } from '@services/authService';
+import { useStore } from '@stores/useStore';
 import { UpdatePasswordForm } from '@/types/UserType';
-import useStore from '@/stores/useStore';
 
 export default function UserPasswordSettingPage() {
-  const isVerified = useStore((state) => state.isVerified);
+  const { isVerified } = useStore();
   const navigate = useNavigate();
   const { toastSuccess, toastError } = useToast();
   const {

--- a/src/pages/setting/UserSettingPage.tsx
+++ b/src/pages/setting/UserSettingPage.tsx
@@ -1,14 +1,14 @@
 import { FormProvider, useForm } from 'react-hook-form';
-import { USER_INFO_DUMMY } from '@mocks/mockData';
 import { USER_AUTH_VALIDATION_RULES } from '@constants/formValidationRules';
 import ValidationInput from '@components/common/ValidationInput';
 import ProfileImageContainer from '@components/user/auth-form/ProfileImageContainer';
 import LinkContainer from '@components/user/auth-form/LinkContainer';
+import { USER_INFO_DUMMY } from '@mocks/mockData';
 import { useStore } from '@stores/useStore';
 import type { EditUserInfoForm } from '@/types/UserType';
 
 export default function UserSettingPage() {
-  const userInfoData = useStore((state) => state.userInfo);
+  const { userInfo: userInfoData } = useStore();
 
   const methods = useForm<EditUserInfoForm>({
     mode: 'onChange',

--- a/src/pages/user/SearchIdPage.tsx
+++ b/src/pages/user/SearchIdPage.tsx
@@ -20,7 +20,7 @@ export default function SearchIdPage() {
     mode: 'onChange',
     defaultValues: {
       email: '',
-      code: '',
+      verificationCode: '',
     },
   });
   const { handleSubmit, setError, setValue } = methods;
@@ -33,11 +33,11 @@ export default function SearchIdPage() {
 
   // ToDo: useAxios 훅 적용 후 해당 함수 수정 및 삭제하기
   const handleVerificationError = () => {
-    setError('code', {
+    setError('verificationCode', {
       type: 'manual',
       message: '인증번호가 일치하지 않습니다.',
     });
-    setValue('code', '');
+    setValue('verificationCode', '');
   };
 
   // ToDo: useAxios 훅을 이용한 네트워크 로직으로 변경

--- a/src/pages/user/SearchPasswordPage.tsx
+++ b/src/pages/user/SearchPasswordPage.tsx
@@ -20,7 +20,7 @@ export default function SearchPasswordPage() {
     defaultValues: {
       username: '',
       email: '',
-      code: '',
+      verificationCode: '',
     },
   });
   const { handleSubmit, setError, setValue } = methods;
@@ -33,11 +33,11 @@ export default function SearchPasswordPage() {
 
   // ToDo: useAxios 훅 적용 후 해당 함수 수정 및 삭제하기
   const handleVerificationError = () => {
-    setError('code', {
+    setError('verificationCode', {
       type: 'manual',
       message: '인증번호가 일치하지 않습니다.',
     });
-    setValue('code', '');
+    setValue('verificationCode', '');
   };
 
   // ToDo: useAxios 훅을 이용한 네트워크 로직으로 변경

--- a/src/pages/user/SignUpPage.tsx
+++ b/src/pages/user/SignUpPage.tsx
@@ -94,7 +94,7 @@ export default function SignUpPage() {
           <ValidationInput
             label="인증번호"
             errors={methods.formState.errors.verificationCode?.message}
-            register={methods.register('verificationCode', USER_AUTH_VALIDATION_RULES.CERTIFICATION)}
+            register={methods.register('verificationCode', USER_AUTH_VALIDATION_RULES.VERIFICATION_CODE)}
           />
         )}
 

--- a/src/pages/user/SignUpPage.tsx
+++ b/src/pages/user/SignUpPage.tsx
@@ -20,7 +20,7 @@ export default function SignUpPage() {
     defaultValues: {
       username: null,
       email: '',
-      code: '',
+      verificationCode: '',
       nickname: '',
       password: '',
       checkPassword: '',
@@ -32,12 +32,12 @@ export default function SignUpPage() {
 
   // form 전송 함수
   const onSubmit = async (data: UserSignUpForm) => {
-    const { username, code, checkPassword, profileImageName, ...filteredData } = data;
+    const { username, verificationCode, checkPassword, profileImageName, ...filteredData } = data;
     console.log(data);
     // TODO: 폼 제출 로직 수정 필요
     try {
       // 회원가입 폼
-      const formData = { ...filteredData, username, code, profileImageName };
+      const formData = { ...filteredData, username, verificationCode, profileImageName };
       const registrationResponse = await axios.post(`http://localhost:8080/api/v1/user/${username}`, formData);
       if (registrationResponse.status !== 200) return toastError('회원가입에 실패했습니다. 다시 시도해 주세요.');
 
@@ -93,8 +93,8 @@ export default function SignUpPage() {
         {isVerificationRequested && (
           <ValidationInput
             label="인증번호"
-            errors={methods.formState.errors.code?.message}
-            register={methods.register('code', USER_AUTH_VALIDATION_RULES.CERTIFICATION)}
+            errors={methods.formState.errors.verificationCode?.message}
+            register={methods.register('verificationCode', USER_AUTH_VALIDATION_RULES.CERTIFICATION)}
           />
         )}
 

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -96,7 +96,7 @@ export async function sendEmailCode(email: RequestEmailCode, axiosConfig: AxiosR
  * @returns {Promise<AxiosResponse>}
  */
 export async function checkEmailCode(verifyForm: EmailVerificationForm, axiosConfig: AxiosRequestConfig = {}) {
-  return defaultAxios.post('user/verify/code', verifyForm, axiosConfig);
+  return authAxios.post('user/verify/code', verifyForm, axiosConfig);
 }
 
 /**

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -74,7 +74,7 @@ export async function postTest(axiosConfig: AxiosRequestConfig = {}) {
 }
 
 /**
- * 이메일 인증 API
+ * 이메일 인증 번호 발송 요청 API
  *
  * @export
  * @async
@@ -84,6 +84,19 @@ export async function postTest(axiosConfig: AxiosRequestConfig = {}) {
  */
 export async function sendEmailCode(email: RequestEmailCode, axiosConfig: AxiosRequestConfig = {}) {
   return authAxios.post('user/verify/send', email, axiosConfig);
+}
+
+/**
+ * 이메일 인증 번호 확인 API
+ *
+ * @export
+ * @async
+ * @param {EmailVerificationForm} verifyForm - 이메일, 인증번호 폼
+ * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
+ * @returns {Promise<AxiosResponse>}
+ */
+export async function checkEmailCode(verifyForm: EmailVerificationForm, axiosConfig: AxiosRequestConfig = {}) {
+  return defaultAxios.post('user/verify/code', verifyForm, axiosConfig);
 }
 
 /**

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -83,7 +83,7 @@ export async function postTest(axiosConfig: AxiosRequestConfig = {}) {
  * @returns {Promise<AxiosResponse>}
  */
 export async function sendEmailCode(email: RequestEmailCode, axiosConfig: AxiosRequestConfig = {}) {
-  return authAxios.post('user/verify/send', email, axiosConfig);
+  return defaultAxios.post('user/verify/send', email, axiosConfig);
 }
 
 /**

--- a/src/services/axiosProvider.ts
+++ b/src/services/axiosProvider.ts
@@ -57,7 +57,7 @@ export const Interceptor = ({ children }: InterceptorProps) => {
     const responseInterceptor = authAxios.interceptors.response.use(
       (response) => response,
       async (error) => {
-        const originalRequest = { ...error.config };
+        const originalRequest = error.config; // 에러 객체의 설정 객체 추출
 
         // 액세스 토큰 만료 시 처리
         if (error.response?.status === 401 && !originalRequest.isRetry) {

--- a/src/services/axiosProvider.ts
+++ b/src/services/axiosProvider.ts
@@ -57,7 +57,7 @@ export const Interceptor = ({ children }: InterceptorProps) => {
     const responseInterceptor = authAxios.interceptors.response.use(
       (response) => response,
       async (error) => {
-        const originalRequest = error.config;
+        const originalRequest = { ...error.config };
 
         // 액세스 토큰 만료 시 처리
         if (error.response?.status === 401 && !originalRequest.isRetry) {
@@ -66,7 +66,6 @@ export const Interceptor = ({ children }: InterceptorProps) => {
           // TODO: 에러 응답 완성 후 리프레시 토큰 오류 감지 로직 수정
           if (!errorMessage.includes('리프레시 토큰이 유효하지 않습니다.')) return Promise.reject(error);
 
-          if (originalRequest.isRetry) return;
           originalRequest.isRetry = true;
 
           try {

--- a/src/services/axiosProvider.ts
+++ b/src/services/axiosProvider.ts
@@ -3,10 +3,10 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { SECOND } from '@constants/units';
 import { JWT_TOKEN_DUMMY } from '@mocks/mockData';
-import type { AxiosInstance, AxiosRequestConfig } from 'axios';
 import useToast from '@hooks/useToast';
 import { getAccessToken } from '@services/authService';
 import { useStore } from '@stores/useStore';
+import type { AxiosInstance, AxiosRequestConfig } from 'axios';
 
 type InterceptorProps = {
   children: ReactNode;
@@ -61,6 +61,12 @@ export const Interceptor = ({ children }: InterceptorProps) => {
 
         // 액세스 토큰 만료 시 처리
         if (error.response?.status === 401 && !originalRequest.isRetry) {
+          const errorMessage = error.response.data?.message || '';
+
+          // TODO: 에러 응답 완성 후 리프레시 토큰 오류 감지 로직 수정
+          if (!errorMessage.includes('리프레시 토큰이 유효하지 않습니다.')) return Promise.reject(error);
+
+          if (originalRequest.isRetry) return;
           originalRequest.isRetry = true;
 
           try {

--- a/src/services/axiosProvider.ts
+++ b/src/services/axiosProvider.ts
@@ -57,9 +57,11 @@ export const Interceptor = ({ children }: InterceptorProps) => {
     const responseInterceptor = authAxios.interceptors.response.use(
       (response) => response,
       async (error) => {
+        const originalRequest = error.config;
+
         // 액세스 토큰 만료 시 처리
-        if (error.response?.status === 401) {
-          const originalRequest = error.config; // 에러 객체의 설정 객체 추출
+        if (error.response?.status === 401 && !originalRequest.isRetry) {
+          originalRequest.isRetry = true;
 
           try {
             // 리프레시 토큰을 이용해 새로운 액세스 토큰 발급

--- a/src/stores/useStore.ts
+++ b/src/stores/useStore.ts
@@ -8,9 +8,11 @@ import { User } from '@/types/UserType';
 type AuthStore = {
   isAuthenticated: boolean;
   accessToken: string | null;
+  isVerified: boolean;
 
   setAccessToken: (token: string) => void;
   onLogin: (token: string) => void;
+  onVerifyCode: () => void;
   onLogout: () => void;
 };
 
@@ -28,6 +30,7 @@ type Store = AuthStore & UserStore;
 const createAuthSlice: StateCreator<Store, [], [], AuthStore> = (set) => ({
   isAuthenticated: false,
   accessToken: null,
+  isVerified: false,
 
   setAccessToken: (token: string) =>
     set({
@@ -46,6 +49,18 @@ const createAuthSlice: StateCreator<Store, [], [], AuthStore> = (set) => ({
         accessToken: null,
       });
     }, AUTH_SETTINGS.ACCESS_TOKEN_EXPIRATION);
+  },
+
+  onVerifyCode: () => {
+    set({
+      isVerified: true,
+    });
+
+    setTimeout(() => {
+      set({
+        isVerified: false,
+      });
+    }, AUTH_SETTINGS.VERIFIED_EXPIRATION);
   },
 
   onLogout: () => {

--- a/src/types/UserType.tsx
+++ b/src/types/UserType.tsx
@@ -17,7 +17,7 @@ export type UserWithRole = SearchUser & Pick<Role, 'roleName'>;
 export type EditUserInfoForm = Omit<User, 'userId' | 'provider'>;
 
 export type UserSignUpForm = Omit<User, 'userId' | 'provider'> & {
-  code: string;
+  verificationCode: string;
   password: string;
   checkPassword: string;
 };
@@ -26,9 +26,9 @@ export type UserSignInForm = Pick<User, 'username'> & {
   password: string;
 };
 
-export type EmailVerificationForm = Pick<User, 'email'> & { code: string };
+export type EmailVerificationForm = Pick<User, 'email'> & { verificationCode: string };
 
-export type SearchPasswordForm = Pick<User, 'username' | 'email'> & { code: string };
+export type SearchPasswordForm = Pick<User, 'username' | 'email'> & { verificationCode: string };
 
 export type UpdatePasswordForm = {
   password: string;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해 주세요. -->

- [x] **\[Fix\]** 버그를 수정했어요.
- [x] **\[Formatting\]** 코드 스타일 업데이트를 했어요(포맷팅, 변수명 변경 etc)
- [x] **\[Feat\]** 새로운 기능을 추가했어요.

## Related Issues

<!--#을 눌러 이슈와 연결해 주세요-->
#146 비밀번호 변경 전 인증 페이지의 인증 로직 구현

## What does this PR do?

<!--무엇을 하셨나요?-->

- [x] 인증 페이지의 이메일 인증 로직 구현
- [x] 이메일 인증 정보를 Zustand에 지정된 시간 동안 저장
    - [x] 인증 정보가 만료되지 않았을 시, 비밀번호 변경 페이지에 접근 가능
    - [x] 인증 정보 만료 시, 인증 페이지로 리다이렉션
- [x] 이메일 인증 코드 변수명을 `code` -> `verificationCode`로 변경
- [x] `authAxios`를 사용하는 API에서 401에러 코드를 응답으로 받았을 때 로그인 화면으로 강제 이동하는 에러 수정

## Other information
![리다이렉션](https://github.com/user-attachments/assets/f4ee2a15-123e-4e83-9786-88b6c84a506e)
만료시간을 6초로 설정한 뒤 테스트해보았습니다. 


## Other information

<!--참고한 자료, 추가적인 사항, 기타 의견-->
- 아직 `이메일 인증 확인 API`가 만들어지지 않은 상태라 임의로 엔드포인트와 응답을 설정해서 기능을 구현했습니다.
- 새로고침 시 이메일 인증이 초기화되는 문제는 추후 새로고침 시 `isAuthenticated` 변수가 초기화되는 문제와 함께 따로 구현해 PR 올리도록 하겠습니다.
- authAxios를 사용하는 API가 401에러 코드를 응답으로 받으면, 리프레시 토큰 오류로 처리되어서 강제로 로그인 화면으로 이동하는 에러가 있었습니다. 해당 에러를 수정하기 위해 리프레시 토큰 만료 시 오류메시지를 체크하도록 설정해 놓았는데, 이 부분은 나중에 에러 핸들링 구현이 어느 정도 완료되면 조금 더 명확한 방식으로 에러 체킹을 하도록 변경하겠습니다.  
