### PR TITLE
Feat: #115 일정 등록 모달의 파일 업로드 기능 구현

### DIFF
--- a/src/components/common/FileDropZone.tsx
+++ b/src/components/common/FileDropZone.tsx
@@ -6,6 +6,7 @@ type FileDropZoneProps = {
   id: string;
   label: string;
   files: FileInfo[];
+  accept: string;
   onFileDrop: (e: React.DragEvent<HTMLElement>) => void;
   onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onFileDeleteClick: (fileId: string) => void;
@@ -14,11 +15,11 @@ type FileDropZoneProps = {
 const DEFAULT_BG_COLOR = 'inherit';
 const FILE_DRAG_OVER_BG_COLOR = '#e1f4d9';
 
-// ToDo: 파일 업로드 API 작업시 구조 다시 한 번 확인해보기
 export default function FileDropZone({
   id,
   label,
   files,
+  accept = '*',
   onFileDrop,
   onFileChange: handleFileChange,
   onFileDeleteClick: handleFileDeleteClick,
@@ -41,7 +42,15 @@ export default function FileDropZone({
   return (
     <label htmlFor={id}>
       <h3 className="text-large">{label}</h3>
-      <input type="file" id={id} className="h-0 w-0 opacity-0" multiple hidden onChange={handleFileChange} />
+      <input
+        id={id}
+        type="file"
+        accept={accept}
+        className="h-0 w-0 opacity-0"
+        onChange={handleFileChange}
+        multiple
+        hidden
+      />
       <div
         role="button"
         tabIndex={0}

--- a/src/components/modal/task/CreateModalTask.tsx
+++ b/src/components/modal/task/CreateModalTask.tsx
@@ -56,15 +56,7 @@ export default function CreateModalTask({ project, onClose: handleClose }: Creat
         else rejectedFileList.push(result);
       });
 
-    if (fulfilledFileList.length > 0) {
-      const fulfilledFilesName = fulfilledFileList.map((result) => result.file.name).join(', ');
-      toastSuccess(`${fulfilledFilesName} 파일 업로드에 성공했습니다.`);
-    }
-
-    if (rejectedFileList.length > 0) {
-      const rejectedFilesName = rejectedFileList.map((result) => result.file.name).join(', ');
-      toastError(`${rejectedFilesName} 파일 업로드에 실패했습니다.`);
-    }
+    if (fulfilledFileList.length > 0) toastSuccess(`${fulfilledFileList.length}개의 파일 업로드에 성공했습니다.`);
   };
 
   const handleSubmit: SubmitHandler<TaskForm> = async (taskFormData) => {

--- a/src/components/modal/task/CreateModalTask.tsx
+++ b/src/components/modal/task/CreateModalTask.tsx
@@ -1,12 +1,12 @@
+import { useQueryClient } from '@tanstack/react-query';
 import ModalLayout from '@layouts/ModalLayout';
 import ModalPortal from '@components/modal/ModalPortal';
 import ModalTaskForm from '@components/modal/task/ModalTaskForm';
 import ModalFormButton from '@components/modal/ModalFormButton';
-import { useCreateStatusTask, useReadStatusTasks, useUploadTaskFile } from '@hooks/query/useTaskQuery';
 import useToast from '@hooks/useToast';
+import { useCreateStatusTask, useReadStatusTasks, useUploadTaskFile } from '@hooks/query/useTaskQuery';
 
 import type { SubmitHandler } from 'react-hook-form';
-import { useQueryClient } from '@tanstack/react-query';
 import type { Task, TaskForm } from '@/types/TaskType';
 import type { Project } from '@/types/ProjectType';
 import type { ProjectStatus } from '@/types/ProjectStatusType';

--- a/src/components/modal/task/ModalTaskForm.tsx
+++ b/src/components/modal/task/ModalTaskForm.tsx
@@ -111,19 +111,19 @@ export default function ModalTaskForm({ formId, project, taskId, onSubmit }: Mod
   const isValidTaskFile = (file: File) => {
     if (!Validator.isValidFileName(file.name)) {
       toastWarn(
-        `${file.name}은/는 업로드 할 수 없습니다. 파일명은 한글, 영어, 숫자, 특수기호(.-_), 공백문자만 가능합니다.`,
+        `${file.name} 파일은 업로드 할 수 없습니다. 파일명은 한글, 영어, 숫자, 특수기호(.-_), 공백문자만 가능합니다.`,
       );
       return false;
     }
 
     if (!Validator.isValidFileExtension(TASK_SETTINGS.FILE_TYPES, file.type)) {
-      toastWarn(`${file.name}은/는 업로드 할 수 없습니다. 지원하지 않는 파일 타입입니다.`);
+      toastWarn(`${file.name} 파일은 업로드 할 수 없습니다. 지원하지 않는 파일 타입입니다.`);
       return false;
     }
 
     if (!Validator.isValidFileSize(TASK_SETTINGS.MAX_FILE_SIZE, file.size)) {
       toastWarn(
-        `${file.name}은/는 업로드 할 수 없습니다. 최대 ${convertBytesToString(TASK_SETTINGS.MAX_FILE_SIZE)} 이하의 파일만 업로드 가능합니다.`,
+        `${file.name} 파일은 업로드 할 수 없습니다. ${convertBytesToString(TASK_SETTINGS.MAX_FILE_SIZE)} 이하의 파일만 업로드 가능합니다.`,
       );
       return false;
     }

--- a/src/components/modal/task/ModalTaskForm.tsx
+++ b/src/components/modal/task/ModalTaskForm.tsx
@@ -17,6 +17,7 @@ import useAxios from '@hooks/useAxios';
 import { useReadStatuses } from '@hooks/query/useStatusQuery';
 import { useReadStatusTasks } from '@hooks/query/useTaskQuery';
 import { useReadProjectUserRoleList } from '@hooks/query/useProjectQuery';
+import Validator from '@utils/Validator';
 import { convertBytesToString } from '@utils/converter';
 import { findUserByProject } from '@services/projectService';
 
@@ -106,22 +107,46 @@ export default function ModalTaskForm({ formId, project, taskId, onSubmit }: Mod
     setValue('assignees', assigneesIdList);
   };
 
-  const updateFiles = (newFiles: FileList) => {
+  // ToDo: 일정 수정에서도 사용하도록 분리할 것, 어디에 분리하는게 좋으려나?
+  const isValidTaskFile = (file: File) => {
+    if (!Validator.isValidFileName(file.name)) {
+      toastWarn(
+        `${file.name}은/는 업로드 할 수 없습니다. 파일명은 한글, 영어, 숫자, 특수기호(.-_), 공백문자만 가능합니다.`,
+      );
+      return false;
+    }
+
+    if (!Validator.isValidFileExtension(TASK_SETTINGS.FILE_TYPES, file.type)) {
+      toastWarn(`${file.name}은/는 업로드 할 수 없습니다. 지원하지 않는 파일 타입입니다.`);
+      return false;
+    }
+
+    if (!Validator.isValidFileSize(TASK_SETTINGS.MAX_FILE_SIZE, file.size)) {
+      toastWarn(
+        `${file.name}은/는 업로드 할 수 없습니다. 최대 ${convertBytesToString(TASK_SETTINGS.MAX_FILE_SIZE)} 이하의 파일만 업로드 가능합니다.`,
+      );
+      return false;
+    }
+
+    return true;
+  };
+
+  const updateTaskFiles = (newFiles: FileList) => {
     // 최대 파일 등록 개수 확인
-    if (files.length + newFiles.length > TASK_SETTINGS.MAX_FILE_COUNT) {
+    if (!Validator.isValidFileCount(TASK_SETTINGS.MAX_FILE_COUNT, files.length + newFiles.length)) {
       return toastWarn(`최대로 등록 가능한 파일수는 ${TASK_SETTINGS.MAX_FILE_COUNT}개입니다.`);
     }
 
-    // 새로운 파일별 파일 크기 확인 & 고유 ID 부여
+    // 새로운 파일 Validation & 고유 ID 부여
     const originFiles: File[] = files.map(({ file }) => file);
     const customFiles: CustomFile[] = [];
     for (let i = 0; i < newFiles.length; i++) {
       const file = newFiles[i];
-      if (file.size > TASK_SETTINGS.MAX_FILE_SIZE) {
-        return toastWarn(`최대 ${convertBytesToString(TASK_SETTINGS.MAX_FILE_SIZE)} 이하의 파일만 업로드 가능합니다.`);
+
+      if (isValidTaskFile(file)) {
+        originFiles.push(file);
+        customFiles.push({ fileId: `${file.name}_${Date.now()}`, fileName: file.name, file });
       }
-      originFiles.push(file);
-      customFiles.push({ fileId: `${file.name}_${Date.now()}`, fileName: file.name, file });
     }
     setValue('files', originFiles);
     setFiles((prev) => [...prev, ...customFiles]);
@@ -130,13 +155,13 @@ export default function ModalTaskForm({ formId, project, taskId, onSubmit }: Mod
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = e.target;
     if (!files || files.length === 0) return;
-    updateFiles(files);
+    updateTaskFiles(files);
   };
 
   const handleFileDrop = (e: React.DragEvent<HTMLElement>) => {
     const { files } = e.dataTransfer;
     if (!files || files.length === 0) return;
-    updateFiles(files);
+    updateTaskFiles(files);
   };
 
   const handleFileDeleteClick = (fileId: string) => {
@@ -194,6 +219,7 @@ export default function ModalTaskForm({ formId, project, taskId, onSubmit }: Mod
           id="files"
           label="첨부파일"
           files={files}
+          accept=".jpg, .jpeg, .png, .svg, .webp, .pdf, .txt, .doc, .docx, .xls, .xlsx, .ppt, .pptx, .hwp, .zip, .rar, .7z, .alz, .egg"
           onFileChange={handleFileChange}
           onFileDrop={handleFileDrop}
           onFileDeleteClick={handleFileDeleteClick}

--- a/src/components/modal/task/ModalTaskForm.tsx
+++ b/src/components/modal/task/ModalTaskForm.tsx
@@ -219,7 +219,7 @@ export default function ModalTaskForm({ formId, project, taskId, onSubmit }: Mod
           id="files"
           label="첨부파일"
           files={files}
-          accept=".jpg, .jpeg, .png, .svg, .webp, .pdf, .txt, .doc, .docx, .xls, .xlsx, .ppt, .pptx, .hwp, .zip, .rar, .7z, .alz, .egg"
+          accept={TASK_SETTINGS.FILE_ACCEPT}
           onFileChange={handleFileChange}
           onFileDrop={handleFileDrop}
           onFileDeleteClick={handleFileDeleteClick}

--- a/src/components/modal/task/UpdateModalTask.tsx
+++ b/src/components/modal/task/UpdateModalTask.tsx
@@ -193,7 +193,7 @@ export default function UpdateModalTask({ project, taskId, onClose: handleClose 
           id="files"
           label="첨부파일"
           files={taskFileList}
-          accept=".jpg, .jpeg, .png, .svg, .webp, .pdf, .txt, .doc, .docx, .xls, .xlsx, .ppt, .pptx, .hwp, .zip, .rar, .7z, .alz, .egg"
+          accept={TASK_SETTINGS.FILE_ACCEPT}
           onFileChange={handleFileChange}
           onFileDrop={handleFileDrop}
           onFileDeleteClick={handleFileDeleteClick}

--- a/src/components/modal/task/UpdateModalTask.tsx
+++ b/src/components/modal/task/UpdateModalTask.tsx
@@ -193,6 +193,7 @@ export default function UpdateModalTask({ project, taskId, onClose: handleClose 
           id="files"
           label="첨부파일"
           files={taskFileList}
+          accept=".jpg, .jpeg, .png, .svg, .webp, .pdf, .txt, .doc, .docx, .xls, .xlsx, .ppt, .pptx, .hwp, .zip, .rar, .7z, .alz, .egg"
           onFileChange={handleFileChange}
           onFileDrop={handleFileDrop}
           onFileDeleteClick={handleFileDeleteClick}

--- a/src/constants/mimeFileType.ts
+++ b/src/constants/mimeFileType.ts
@@ -1,0 +1,44 @@
+// 이미지 파일
+export const JPG = 'image/jpeg';
+export const PNG = 'image/png';
+export const SVG = 'image/svg+xml';
+export const WEBP = 'image/webp';
+
+// 압축 파일
+export const ZIP = 'application/zip';
+export const RAR = 'application/x-rar-compressed';
+export const Z7 = 'application/x-7z-compressed';
+export const ALZ = 'application/x-alz';
+export const EGG = 'application/x-egg';
+
+// 문서 파일
+export const TXT = 'text/plain';
+export const PDF = 'application/pdf';
+export const HWP = 'application/x-hwp';
+export const DOC = 'application/msword';
+export const XLS = 'application/vnd.ms-excel';
+export const PPT = 'application/vnd.ms-powerpoint';
+export const DOCX = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+export const XLSX = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+export const PPTX = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+
+export const TASK_ACCEPT_FILE_TYPES = [
+  JPG,
+  PNG,
+  SVG,
+  WEBP,
+  ZIP,
+  RAR,
+  Z7,
+  ALZ,
+  EGG,
+  PDF,
+  TXT,
+  HWP,
+  DOC,
+  XLS,
+  PPT,
+  DOCX,
+  XLSX,
+  PPTX,
+];

--- a/src/constants/regex.ts
+++ b/src/constants/regex.ts
@@ -1,5 +1,6 @@
 import { USER_SETTINGS } from '@constants/settings';
 
+export const FILE_NAME_REGEX = /^[가-힣a-zA-Z0-9 _\-.]+$/;
 export const EMAIL_REGEX = /^[a-z0-9._%+-]+@[a-z0-9-]+\.[a-z]{2,3}(?:\.[a-z]{2,3})?$/i;
 export const PHONE_REGEX = /^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$/;
 export const PASSWORD_REGEX = new RegExp(

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -19,8 +19,10 @@ export const USER_SETTINGS = Object.freeze({
   MAX_EMAIL_LENGTH: 128,
 });
 
+// prettier-ignore
 export const TASK_SETTINGS = Object.freeze({
   MAX_FILE_SIZE: 2 * MB,
   MAX_FILE_COUNT: 10,
+  FILE_ACCEPT: '.jpg, .jpeg, .png, .svg, .webp, .pdf, .txt, .doc, .docx, .xls, .xlsx, .ppt, .pptx, .hwp, .zip, .rar, .7z, .alz, .egg',
   FILE_TYPES: TASK_ACCEPT_FILE_TYPES,
 });

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -1,4 +1,5 @@
 import { DAY, MB, MINUTE, SECOND } from '@constants/units';
+import { TASK_ACCEPT_FILE_TYPES } from '@constants/mimeFileType';
 
 export const AUTH_SETTINGS = Object.freeze({
   // ACCESS_TOKEN_EXPIRATION: 5 * SECOND, // 테스트용 5초
@@ -21,4 +22,5 @@ export const USER_SETTINGS = Object.freeze({
 export const TASK_SETTINGS = Object.freeze({
   MAX_FILE_SIZE: 2 * MB,
   MAX_FILE_COUNT: 10,
+  FILE_TYPES: TASK_ACCEPT_FILE_TYPES,
 });

--- a/src/hooks/query/useTaskQuery.ts
+++ b/src/hooks/query/useTaskQuery.ts
@@ -9,6 +9,7 @@ import {
   findTaskList,
   updateTaskInfo,
   updateTaskOrder,
+  uploadTaskFile,
 } from '@services/taskService';
 import useToast from '@hooks/useToast';
 
@@ -17,10 +18,11 @@ import type { Project } from '@/types/ProjectType';
 import type {
   Task,
   TaskCreationForm,
-  TaskInfoForm,
+  TaskFilesForm,
   TaskListWithStatus,
   TaskOrder,
   TaskUpdateForm,
+  TaskUploadForm,
 } from '@/types/TaskType';
 
 function getTaskNameList(taskList: TaskListWithStatus[], excludedTaskName?: Task['name']) {
@@ -35,16 +37,31 @@ function getTaskNameList(taskList: TaskListWithStatus[], excludedTaskName?: Task
 // Todo: Task Query D로직 작성하기
 // 일정 생성
 export function useCreateStatusTask(projectId: Project['projectId']) {
-  const { toastSuccess } = useToast();
+  const { toastError, toastSuccess } = useToast();
   const queryClient = useQueryClient();
   const queryKey = ['projects', projectId, 'tasks'];
 
   const mutation = useMutation({
     mutationFn: (formData: TaskCreationForm) => createTask(projectId, formData),
+    onError: () => {
+      toastError('프로젝트 일정 등록 중 오류가 발생했습니다. 잠시후 다시 등록해주세요.');
+    },
     onSuccess: () => {
       toastSuccess('프로젝트 일정을 등록하였습니다.');
       queryClient.invalidateQueries({ queryKey });
     },
+  });
+
+  return mutation;
+}
+
+// 일정 단일 파일 업로드
+export function useUploadTaskFile(projectId: Project['projectId']) {
+  const mutation = useMutation({
+    mutationFn: ({ taskId, file }: TaskUploadForm) =>
+      uploadTaskFile(projectId, taskId, file, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      }),
   });
 
   return mutation;

--- a/src/hooks/query/useTaskQuery.ts
+++ b/src/hooks/query/useTaskQuery.ts
@@ -18,7 +18,6 @@ import type { Project } from '@/types/ProjectType';
 import type {
   Task,
   TaskCreationForm,
-  TaskFilesForm,
   TaskListWithStatus,
   TaskOrder,
   TaskUpdateForm,
@@ -57,11 +56,13 @@ export function useCreateStatusTask(projectId: Project['projectId']) {
 
 // 일정 단일 파일 업로드
 export function useUploadTaskFile(projectId: Project['projectId']) {
+  const { toastError } = useToast();
   const mutation = useMutation({
     mutationFn: ({ taskId, file }: TaskUploadForm) =>
       uploadTaskFile(projectId, taskId, file, {
         headers: { 'Content-Type': 'multipart/form-data' },
       }),
+    onError: (error, { file }) => toastError(`${file.name} 파일 업로드에 실패 했습니다.`),
   });
 
   return mutation;

--- a/src/mocks/mockData.ts
+++ b/src/mocks/mockData.ts
@@ -32,6 +32,12 @@ type TaskFile = {
   fileUrl: string;
 };
 
+type FileInfo = {
+  fileId: number;
+  taskId: number;
+  file: Blob;
+};
+
 export const JWT_TOKEN_DUMMY = 'mocked-header.mocked-payload-4.mocked-signature';
 
 export const emailVerificationCode = '1234';
@@ -689,19 +695,38 @@ export const TASK_FILE_DUMMY: TaskFile[] = [
   {
     fileId: 1,
     taskId: 1,
-    fileName: '최종본.pdf',
+    fileName: '최종본.txt',
     fileUrl: '',
   },
   {
     fileId: 2,
     taskId: 1,
-    fileName: '참고자료.pdf',
+    fileName: '참고자료.txt',
     fileUrl: '',
   },
   {
     fileId: 3,
     taskId: 2,
-    fileName: '명세서.pdf',
+    fileName: '명세서.txt',
     fileUrl: '',
+  },
+];
+
+// MSW 파일 임시 저장을 위한 변수
+export const FILE_DUMMY: FileInfo[] = [
+  {
+    fileId: 1,
+    taskId: 1,
+    file: new Blob(['최종본 내용'], { type: 'text/plain' }),
+  },
+  {
+    fileId: 2,
+    taskId: 1,
+    file: new Blob(['참고자료 내용'], { type: 'text/plain' }),
+  },
+  {
+    fileId: 3,
+    taskId: 2,
+    file: new Blob(['명세서 내용'], { type: 'text/plain' }),
   },
 ];

--- a/src/mocks/mockHash.ts
+++ b/src/mocks/mockHash.ts
@@ -6,6 +6,7 @@ import type { Project } from '@/types/ProjectType';
 import type { ProjectStatus } from '@/types/ProjectStatusType';
 import type { Task } from '@/types/TaskType';
 
+// ToDo: undefined가 나올 수도 있음, 나중에 MSW CRUD 관련 로직들 함수로 모두 정리하기.
 type Hash<T> = {
   [key: string | number]: T;
 };

--- a/src/mocks/services/taskServiceHandler.ts
+++ b/src/mocks/services/taskServiceHandler.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from 'msw';
 import {
+  FILE_DUMMY,
   PROJECT_DUMMY,
   PROJECT_USER_DUMMY,
   STATUS_DUMMY,
@@ -11,7 +12,7 @@ import {
 import { getRoleHash, getStatusHash, getTaskHash, getUserHash } from '@mocks/mockHash';
 
 import type { UserWithRole } from '@/types/UserType';
-import type { TaskAssigneeForm, TaskCreationForm, TaskInfoForm, TaskOrderForm, TaskUpdateForm } from '@/types/TaskType';
+import type { TaskAssigneeForm, TaskCreationForm, TaskOrderForm, TaskUpdateForm } from '@/types/TaskType';
 
 const BASE_URL = import.meta.env.VITE_BASE_URL;
 
@@ -51,8 +52,46 @@ const taskServiceHandler = [
 
     const taskId = TASK_DUMMY.length + 1;
     assignees.forEach((userId) => TASK_USER_DUMMY.push({ taskId, userId }));
-    TASK_DUMMY.push({ ...taskInfoForm, statusId: +taskInfoForm.statusId, taskId });
-    return new HttpResponse(null, { status: 201 });
+
+    const newTask = { ...taskInfoForm, statusId: +taskInfoForm.statusId, taskId };
+    TASK_DUMMY.push(newTask);
+    return HttpResponse.json(newTask);
+  }),
+  // 일정 단일  파일 업로드
+  http.post(`${BASE_URL}/project/:projectId/task/:taskId/upload`, async ({ request, params }) => {
+    const accessToken = request.headers.get('Authorization');
+    const { projectId, taskId } = params;
+    const formData = await request.formData();
+    const file = formData.get('file');
+
+    if (!accessToken) return new HttpResponse(null, { status: 401 });
+    if (!file) return new HttpResponse(null, { status: 400 });
+    if (!(file instanceof File)) return new HttpResponse('업로드된 문서는 파일이 아닙니다.', { status: 400 });
+
+    // ToDo: JWT의 userId 정보를 가져와 프로젝트 권한 확인이 필요.
+    const project = PROJECT_DUMMY.find((project) => project.projectId === Number(projectId));
+    if (!project) return new HttpResponse(null, { status: 404 });
+
+    const task = TASK_DUMMY.find((task) => task.taskId === Number(taskId));
+    if (!task) return new HttpResponse(null, { status: 404 });
+
+    // TODO: fileURL은 파일 다운로드시 재설정할 것
+    const newFileId = TASK_FILE_DUMMY.length + 1;
+    TASK_FILE_DUMMY.push({
+      fileId: newFileId,
+      taskId: task.taskId,
+      fileName: file.name,
+      fileUrl: '',
+    });
+
+    // MSW 파일 다운로드 테스트를 위해 메모리에 임시 저장
+    FILE_DUMMY.push({
+      fileId: newFileId,
+      taskId: task.taskId,
+      file: new Blob([file], { type: file.type }),
+    });
+
+    return new HttpResponse(null, { status: 200 });
   }),
   // 일정 순서 변경 API
   http.patch(`${BASE_URL}/project/:projectId/task/order`, async ({ request, params }) => {

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -26,14 +26,36 @@ export async function findTaskList(projectId: Project['projectId'], axiosConfig:
  * @param {Project['projectId']} projectId      - 프로젝트 ID
  * @param {TaskCreationForm} formData           - 새로운 일정 정보 객체
  * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
- * @returns {Promise<AxiosResponse<void>>}
+ * @returns {Promise<AxiosResponse<Task>>}
  */
 export function createTask(
   projectId: Project['projectId'],
   formData: TaskCreationForm,
   axiosConfig: AxiosRequestConfig = {},
 ) {
-  return authAxios.post(`/project/${projectId}/task`, formData, axiosConfig);
+  return authAxios.post<Task>(`/project/${projectId}/task`, formData, axiosConfig);
+}
+
+/**
+ * 일정 파일 업로드 API
+ *
+ * @export
+ * @async
+ * @param {Project['projectId']} projectId        - 프로젝트 ID
+ * @param {Task['taskId']} taskId                 - 일정 ID
+ * @param {File} file                             - 단일 파일 객체
+ * @param {AxiosRequestConfig} [axiosConfig={}]   - axios 요청 옵션 설정 객체
+ * @returns {Promise<AxiosResponse<void>>}
+ */
+export async function uploadTaskFile(
+  projectId: Project['projectId'],
+  taskId: Task['taskId'],
+  file: File,
+  axiosConfig: AxiosRequestConfig = {},
+) {
+  const fileFormData = new FormData();
+  fileFormData.append('file', file);
+  return authAxios.postForm(`/project/${projectId}/task/${taskId}/upload`, fileFormData, axiosConfig);
 }
 
 /**

--- a/src/types/FileType.tsx
+++ b/src/types/FileType.tsx
@@ -11,3 +11,13 @@ export type TaskFile = {
 };
 
 export type FileInfo = TaskFile | CustomFile;
+
+export type FileUploadSuccessResult = {
+  status: 'fulfilled';
+  file: File;
+};
+export type FileUploadFailureResult = {
+  status: 'rejected';
+  file: File;
+  error: unknown;
+};

--- a/src/types/TaskType.tsx
+++ b/src/types/TaskType.tsx
@@ -23,12 +23,13 @@ export type TaskOrder = Pick<Task, 'statusId' | 'taskId' | 'sortOrder'>;
 export type TaskOrderForm = { tasks: TaskOrder[] };
 
 export type TaskInfoForm = Omit<Task, 'taskId'>;
-export type TaskFileForm = { files: File[] };
+export type TaskFilesForm = { files: File[] };
 export type TaskAssigneeForm = { userId: User['userId'] };
 export type TaskAssigneesForm = { assignees: User['userId'][] };
 export type TaskUpdateForm = Omit<Task, 'statusId'> & { statusId: string };
 export type TaskCreationForm = TaskInfoForm & TaskAssigneesForm;
-export type TaskForm = TaskInfoForm & TaskAssigneesForm & TaskFileForm;
+export type TaskForm = TaskCreationForm & TaskFilesForm;
+export type TaskUploadForm = Pick<Task, 'taskId'> & { file: File };
 
 export type TaskWithStatus = RenameKeys<Omit<ProjectStatus, 'projectId'>, StatusKeyMapping> & Task;
 export type TaskListWithStatus = Omit<ProjectStatus, 'projectId'> & { tasks: Task[] };

--- a/src/utils/Validator.ts
+++ b/src/utils/Validator.ts
@@ -36,7 +36,7 @@ export default class Validator {
     if (!Validator.isPositiveNumberWithZero(maxCount) || !Validator.isPositiveNumberWithZero(currentCount)) {
       throw Error('최대 파일수와 현재 파일 수는 음수가 될 수 없습니다.');
     }
-    return maxCount >= currentCount;
+    return maxCount > currentCount;
   }
 
   public static isValidFileSize(maxSize: number, fileSize: number) {

--- a/src/utils/Validator.ts
+++ b/src/utils/Validator.ts
@@ -34,17 +34,20 @@ export default class Validator {
 
   public static isValidFileCount(maxCount: number, currentCount: number) {
     if (!Validator.isPositiveNumberWithZero(maxCount) || !Validator.isPositiveNumberWithZero(currentCount)) {
-      throw Error('최대 파일수와 현재 파일 수는 음수가 될 수 없습니다.');
+      throw Error('파일 개수는 음수가 될 수 없습니다.');
     }
     return maxCount >= currentCount;
   }
 
   public static isValidFileSize(maxSize: number, fileSize: number) {
+    if (!Validator.isPositiveNumberWithZero(maxSize) || !Validator.isPositiveNumberWithZero(fileSize)) {
+      throw Error('파일 크기는 음수가 될 수 없습니다.');
+    }
     return maxSize >= fileSize;
   }
 
   public static isValidFileExtension(acceptFileTypes: string[], fileType: string) {
-    return acceptFileTypes.some((acceptFileType) => acceptFileType === fileType);
+    return acceptFileTypes.some((acceptFileType) => acceptFileType.toLowerCase() === fileType.toLowerCase());
   }
 
   public static isValidFileName(fileName: string) {

--- a/src/utils/Validator.ts
+++ b/src/utils/Validator.ts
@@ -36,7 +36,7 @@ export default class Validator {
     if (!Validator.isPositiveNumberWithZero(maxCount) || !Validator.isPositiveNumberWithZero(currentCount)) {
       throw Error('최대 파일수와 현재 파일 수는 음수가 될 수 없습니다.');
     }
-    return maxCount > currentCount;
+    return maxCount >= currentCount;
   }
 
   public static isValidFileSize(maxSize: number, fileSize: number) {

--- a/src/utils/Validator.ts
+++ b/src/utils/Validator.ts
@@ -1,4 +1,5 @@
 import { DateTime } from 'luxon';
+import { FILE_NAME_REGEX } from '@constants/regex';
 
 export default class Validator {
   public static isEmptyString(value: string) {
@@ -25,5 +26,29 @@ export default class Validator {
     const startDate = DateTime.fromJSDate(new Date(start));
     const endDate = DateTime.fromJSDate(new Date(end));
     return startDate <= endDate;
+  }
+
+  public static isPositiveNumberWithZero(num: number) {
+    return typeof num === 'number' && num >= 0;
+  }
+
+  public static isValidFileCount(maxCount: number, currentCount: number) {
+    if (!Validator.isPositiveNumberWithZero(maxCount) || !Validator.isPositiveNumberWithZero(currentCount)) {
+      throw Error('최대 파일수와 현재 파일 수는 음수가 될 수 없습니다.');
+    }
+    return maxCount >= currentCount;
+  }
+
+  public static isValidFileSize(maxSize: number, fileSize: number) {
+    return maxSize >= fileSize;
+  }
+
+  public static isValidFileExtension(acceptFileTypes: string[], fileType: string) {
+    return acceptFileTypes.some((acceptFileType) => acceptFileType === fileType);
+  }
+
+  public static isValidFileName(fileName: string) {
+    const fileNameRegex = new RegExp(FILE_NAME_REGEX);
+    return fileNameRegex.test(fileName);
   }
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] **\[Feat\]** 새로운 기능을 추가했어요.
- [x] **\[UI\]** CSS 등 사용자 UI 디자인 추가/삭제/변경 했어요.
- [x] **\[Comment\]** 필요한 주석 추가/삭제/변경 했어요.
- [x] **\[Chore\]** 빌드 프로세스 변경, 의존성 패키지 업데이트 했어요.

## Related Issues
- close #115 

## What does this PR do?
- [x] 일정 파일 업로드 API를 위한 React Query 처리 추가
- [x] 일정 파일 업로드 API를 위한 MSW 처리 추가
- [x] 파일 Validation 추가 (파일 최대 개수, 파일 크기, 파일명, 파일 확장자)
- [x] 여러 개의 일정 파일을 개별 파일 요청으로 분할하여 병렬 요청하도록 기능 구현
- [x] Task 관련 Form 타입 추가
- [x] FileDropZone Props 추가

## Other information
1. [React Query 공식문서: mutateAsync](https://tanstack.com/query/latest/docs/framework/react/reference/useMutation)
2. [MSW 공식 문서: File uploads](https://mswjs.io/docs/recipes/file-uploads/)
3. [MDN: FormData](https://developer.mozilla.org/ko/docs/Web/API/FormData)
4. [MDN: Promise.allSettled](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled)
5. [MDN: Blob](https://developer.mozilla.org/ko/docs/Web/API/Blob)
6. [MDN: File](https://developer.mozilla.org/ko/docs/Web/API/File)
7. [MDN: Common MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types)
8. [iana: Media Types](https://www.iana.org/assignments/media-types/media-types.xhtml)

MSW를 통해 파일 업로드를 모킹할 필요가 있었습니다. 브라우저 요청에 대한 모킹이라 로컬에 파일을 저장할 수 없어서 메모리에 Blob 객체로 넣어두고, 이후 다운로드 API를 테스트할 때 내려주는 방법으로 진행할 예정입니다.

파일의 병렬적 요청에 대해서는 `Promise.allSettled`와 `Promise.all`를 고려했습니다. all의 경우 하나라도 실패하면 전체를 실패로 간주함을 알게 되었고, 성공/실패에 상관없이 모두가 실행되어 반영되어야하는 이번 구현 상황에선 allSettled가 적절하다고 판단하여 allSettled를 사용하였습니다.

추가적으로 useForm을 사용하고 있어서 보편적인 파일 업로드라면 register의 validation을 사용했을텐데, 드래그 앤 드롭 파일 업로드 기능이 있어서 register의 validation으로 파일을 걸러낼 수 없었습니다. 그래서 별도의 파일 검증 로직을 만들었습니다. 궁금한 점 있으면 편하게 물어봐 주세요☺️

## View
**파일 최대 개수 Validation**
![화면 예시 - 파일 최대 개수](https://github.com/user-attachments/assets/60455a7b-2393-4a05-a0f1-323c6f866a27)

**파일명 Validation**
![화면 예시 - 이름 이상](https://github.com/user-attachments/assets/9b5ac80d-055a-472d-9dba-d611d4a6f667)

**파일 확장자 Validation**
![화면 예시 - 파일 확장자](https://github.com/user-attachments/assets/32eaf0be-500b-4268-ab10-a43cc0f539b4)

**파일 용량 Validation**
![화면 예시 - 용량초과](https://github.com/user-attachments/assets/64e42bf1-f3a5-4f2d-bd42-c6a9c9ff10c5)

**파일 업로드 실패**
![화면 예시 - 파일 업로드 실패2](https://github.com/user-attachments/assets/f0ffedbb-25d8-4845-a7da-b493ed98915c)

**파일 업로드 성공**
![화면 예시 - 파일 업로드 성공2](https://github.com/user-attachments/assets/d1c5a903-8450-4783-bc22-a2b65e00c2e7)

---
아래의 화면은 파일의 업로드 성공/실패에 대한 개별적인 처리가 아니라, 파일명을 묶어서 한 번에 보여주는 방법입니다. 원래는 아래와 같은 방법으로 진행하려고 했으나 최대 10개의 파일을 등록이 가능한 상황에서 한 번에 묶어서 보여주면 메시지가 좋아 보이지 않아서 FE 간의 상의 끝에 성공은 묶어서 몇개의 파일이 성공했는지를 피드백으로 주고 있고, 실패는 개별 메시지로 보여주고 있습니다.

**이전 성공한 파일 목록을 묶어서 보여주는 경우**
![화면 예시 - 파일 업로드 성공](https://github.com/user-attachments/assets/4e72eb55-5b90-4815-8676-ea21b3ba3d92)

**이전 실패한 파일 목록을 묶어서 보여주는 경우**
![화면 예시 - 파일 업로드 실패](https://github.com/user-attachments/assets/57361664-0083-46f2-88fe-1f090911a204)