### PR TITLE
Feat: #159 닉네임 중복 확인 API 및 회원가입 기능 구현

### DIFF
--- a/src/components/common/ValidationInput.tsx
+++ b/src/components/common/ValidationInput.tsx
@@ -15,6 +15,7 @@ import { RiEyeFill, RiEyeOffFill } from 'react-icons/ri';
  * @params {string} [placeholder] - 입력 필드의 placeholder 텍스트
  * @params {boolean} [isButtonInput] - 버튼이 포함된 입력 필드인지 여부. 기본값은 'false'
  * @params {React.ReactNode} [buttonLabel] - 버튼에 표시할 텍스트 또는 아이콘
+ * @params {boolean} [buttonDisabled] - 버튼의 비활성화 여부
  * @params {() => void} [onButtonClick] - 버튼 클릭 시 호출할 함수
  *
  * 예시) 
@@ -39,6 +40,7 @@ type ValidationInputProps = {
   placeholder?: string;
   isButtonInput?: boolean;
   buttonLabel?: React.ReactNode;
+  buttonDisabled?: boolean;
   onButtonClick?: () => void;
 };
 
@@ -52,6 +54,7 @@ export default function ValidationInput({
   placeholder,
   isButtonInput = false,
   buttonLabel,
+  buttonDisabled = false,
   onButtonClick,
 }: ValidationInputProps) {
   const [showPassword, setShowPassword] = useState(false);
@@ -91,7 +94,12 @@ export default function ValidationInput({
           </div>
         )}
         {isButtonInput && (
-          <button type="button" className="h-18 w-75 rounded bg-sub px-8 font-bold" onClick={onButtonClick}>
+          <button
+            type="button"
+            className={`h-18 w-75 rounded ${buttonDisabled ? 'bg-disable' : 'bg-sub'} px-8 font-bold`}
+            onClick={onButtonClick}
+            disabled={buttonDisabled}
+          >
             {buttonLabel}
           </button>
         )}

--- a/src/components/user/auth-form/LinkContainer.tsx
+++ b/src/components/user/auth-form/LinkContainer.tsx
@@ -49,23 +49,27 @@ export default function LinkContainer({ initialLinks }: LinkContainerProps) {
         링크
       </label>
       <div className="space-y-4">
-        {links.map((linkItem) => (
-          <div key={linkItem} className="flex h-25 items-center space-x-8 rounded-lg border border-input px-6 text-sm">
-            <div className="grow overflow-hidden">
-              <a href={`https://${linkItem}`} target="_blank" rel="noopener noreferrer">
-                {linkItem}
-              </a>
-            </div>
-            <button
-              type="button"
-              onClick={() => handleRemoveLink(linkItem)}
-              className="flex size-18 items-center justify-center rounded-lg bg-sub"
-              aria-label="삭제"
+        {links &&
+          links.map((linkItem) => (
+            <div
+              key={linkItem}
+              className="flex h-25 items-center space-x-8 rounded-lg border border-input px-6 text-sm"
             >
-              <FaMinus className="size-8" />
-            </button>
-          </div>
-        ))}
+              <div className="grow overflow-hidden">
+                <a href={`https://${linkItem}`} target="_blank" rel="noopener noreferrer">
+                  {linkItem}
+                </a>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleRemoveLink(linkItem)}
+                className="flex size-18 items-center justify-center rounded-lg bg-sub"
+                aria-label="삭제"
+              >
+                <FaMinus className="size-8" />
+              </button>
+            </div>
+          ))}
         <div
           className={`flex h-25 items-center space-x-8 rounded-lg border border-input px-6 text-sm ${isFocused ? 'bg-white' : 'bg-disable'}`}
         >

--- a/src/hooks/useEmailVerification.ts
+++ b/src/hooks/useEmailVerification.ts
@@ -25,9 +25,9 @@ export default function useEmailVerification() {
   };
 
   // 인증 코드 만료
-  const expireVerificationCode = () => {
+  const expireVerificationCode = (showMessage = true) => {
     setIsVerificationRequested(false);
-    toastError('인증 시간이 만료되었습니다. 다시 시도해 주세요.');
+    if (showMessage) toastError('인증 시간이 만료되었습니다. 다시 시도해 주세요.');
   };
 
   return {

--- a/src/layouts/page/SettingLayout.tsx
+++ b/src/layouts/page/SettingLayout.tsx
@@ -1,7 +1,7 @@
 import { Outlet, useLocation } from 'react-router-dom';
 import ListSidebar from '@components/sidebar/ListSidebar';
 import ListSetting from '@components/sidebar/ListSetting';
-import { USER_INFO_DUMMY } from '@mocks/mockData';
+import useStore from '@stores/useStore';
 
 const navList = [
   {
@@ -20,6 +20,7 @@ const navList = [
 
 export default function SettingLayout() {
   const location = useLocation();
+  const { userInfo } = useStore();
 
   const getTitle = () => {
     const currentPath = location.pathname.split('/')[2];
@@ -30,7 +31,7 @@ export default function SettingLayout() {
 
   return (
     <section className="flex h-full gap-10 p-15">
-      <ListSidebar title={`${USER_INFO_DUMMY.nickname} 님의 정보`}>
+      <ListSidebar title={`${userInfo.nickname} 님의 정보`}>
         <ListSetting navList={navList} />
       </ListSidebar>
       <section className="flex grow flex-col border border-list bg-contents-box">

--- a/src/mocks/mockData.ts
+++ b/src/mocks/mockData.ts
@@ -1,6 +1,6 @@
 import { PROJECT_STATUS_COLORS } from '@constants/projectStatus';
 
-import type { User } from '@/types/UserType';
+import type { UserInfo } from '@/types/UserType';
 import type { Team } from '@/types/TeamType';
 import type { Project } from '@/types/ProjectType';
 import type { ProjectStatus } from '@/types/ProjectStatusType';
@@ -35,24 +35,14 @@ type TaskFile = {
 export const JWT_TOKEN_DUMMY = 'mocked-header.mocked-payload-4.mocked-signature';
 
 export const VERIFICATION_CODE_DUMMY = '1234';
-
-export const USER_INFO_DUMMY = {
-  provider: 'LOCAL',
-  userId: 4,
-  username: 'test123',
-  password: 'qwer@1234',
-  email: 'momoco@gmail.com',
-  nickname: 'momoco',
-  profileImageName: null,
-  bio: "Hi, I'm Momoco!",
-  links: ['momoco@github.com'],
-};
+export const TEMP_PASSWORD_DUMMY = '!1p2l3nqlz';
 
 // 사용자 테이블 Mock (사용자 링크 테이블 포함)
-export const USER_DUMMY: User[] = [
+export const USER_DUMMY: UserInfo[] = [
   {
     userId: 1,
-    username: null,
+    username: 'panda_dev',
+    password: 'password1',
     email: 'one@naver.com',
     provider: 'GOOGLE',
     nickname: '판다',
@@ -62,7 +52,8 @@ export const USER_DUMMY: User[] = [
   },
   {
     userId: 2,
-    username: null,
+    username: 'chameleon_design',
+    password: 'password2',
     email: 'two@naver.com',
     provider: 'KAKAO',
     nickname: '카멜레온',
@@ -72,7 +63,8 @@ export const USER_DUMMY: User[] = [
   },
   {
     userId: 3,
-    username: null,
+    username: 'redpanda_front',
+    password: 'password3',
     email: 'three@naver.com',
     provider: 'GOOGLE',
     nickname: '랫서판다',
@@ -82,7 +74,8 @@ export const USER_DUMMY: User[] = [
   },
   {
     userId: 4,
-    username: null,
+    username: 'polar_bear_front',
+    password: 'password4',
     email: 'four@naver.com',
     provider: 'KAKAO',
     nickname: '북금곰',
@@ -92,7 +85,8 @@ export const USER_DUMMY: User[] = [
   },
   {
     userId: 5,
-    username: null,
+    username: 'tiger_backend',
+    password: 'password5',
     email: 'five@naver.com',
     provider: 'KAKAO',
     nickname: '호랑이',
@@ -102,7 +96,8 @@ export const USER_DUMMY: User[] = [
   },
   {
     userId: 6,
-    username: null,
+    username: 'sloth_fullstack',
+    password: 'password6',
     email: 'six@naver.com',
     provider: 'GOOGLE',
     nickname: '나무늘보',
@@ -112,7 +107,8 @@ export const USER_DUMMY: User[] = [
   },
   {
     userId: 7,
-    username: null,
+    username: 'wombat_backend',
+    password: 'password7',
     email: 'seven@naver.com',
     provider: 'KAKAO',
     nickname: '웜뱃',
@@ -122,7 +118,8 @@ export const USER_DUMMY: User[] = [
   },
   {
     userId: 8,
-    username: null,
+    username: 'beluga_design',
+    password: 'password8',
     email: 'eight@naver.com',
     provider: 'GOOGLE',
     nickname: '벨루가',
@@ -132,7 +129,8 @@ export const USER_DUMMY: User[] = [
   },
   {
     userId: 9,
-    username: null,
+    username: 'penguin_dba',
+    password: 'password9',
     email: 'nine@naver.com',
     provider: 'KAKAO',
     nickname: '펭귄',
@@ -142,7 +140,8 @@ export const USER_DUMMY: User[] = [
   },
   {
     userId: 10,
-    username: null,
+    username: 'beaver_devops',
+    password: 'password10',
     email: 'ten@naver.com',
     provider: 'GOOGLE',
     nickname: '비버',
@@ -153,6 +152,7 @@ export const USER_DUMMY: User[] = [
   {
     userId: 11,
     username: 'eleven',
+    password: 'password11',
     email: 'eleven@naver.com',
     provider: 'LOCAL',
     nickname: '판다아빠',
@@ -163,6 +163,7 @@ export const USER_DUMMY: User[] = [
   {
     userId: 12,
     username: 'twelve',
+    password: 'password12',
     email: 'twelve@naver.com',
     provider: 'LOCAL',
     nickname: '판다엄마',
@@ -173,6 +174,7 @@ export const USER_DUMMY: User[] = [
   {
     userId: 13,
     username: 'thirteen',
+    password: 'password13',
     email: 'thirteen@naver.com',
     provider: 'LOCAL',
     nickname: '판다형',
@@ -183,6 +185,7 @@ export const USER_DUMMY: User[] = [
   {
     userId: 14,
     username: 'fourteen',
+    password: 'password14',
     email: 'fourteen@naver.com',
     provider: 'LOCAL',
     nickname: '판다누나',
@@ -193,6 +196,7 @@ export const USER_DUMMY: User[] = [
   {
     userId: 15,
     username: 'fifteen',
+    password: 'password15',
     email: 'fifteen@naver.com',
     provider: 'LOCAL',
     nickname: '판다동생',
@@ -200,7 +204,106 @@ export const USER_DUMMY: User[] = [
     links: [],
     profileImageName: null,
   },
-] as const;
+  {
+    provider: 'LOCAL',
+    userId: 16,
+    username: 'test123',
+    password: 'qwer@1234',
+    email: 'momoco@gmail.com',
+    nickname: 'momoco',
+    profileImageName: null,
+    bio: "Hi, I'm Momoco!",
+    links: ['momoco@github.com'],
+  },
+  {
+    provider: 'LOCAL',
+    userId: 17,
+    username: 'brown',
+    password: 'test1234!',
+    email: 'brown@example.com',
+    nickname: '브라운',
+    profileImageName: 'Image1.jpg',
+    bio: '게임을 좋아하는 개발자',
+    links: ['brown@example.com'],
+  },
+  {
+    provider: 'KAKAO',
+    userId: 18,
+    username: 'cony',
+    password: 'test1234!',
+    email: 'cony@example.com',
+    nickname: '코니',
+    profileImageName: 'Image2.png',
+    bio: '커피와 책을 사랑하는 디자이너',
+    links: ['cony@example.com'],
+  },
+  {
+    provider: 'GOOGLE',
+    userId: 19,
+    username: 'leonard',
+    password: 'test1234!',
+    email: 'leonard@example.com',
+    nickname: '레너드',
+    profileImageName: 'Image3.jpeg',
+    bio: '자연을 사랑하는 사진작가',
+    links: ['leonard@example.com'],
+  },
+  {
+    provider: 'LOCAL',
+    userId: 20,
+    username: 'sally',
+    password: 'test1234!',
+    email: 'sally@example.com',
+    nickname: '샐리',
+    profileImageName: 'Image1.webp',
+    bio: '24시간이 모자란 워커홀릭 개발자',
+    links: ['sally@example.com'],
+  },
+  {
+    provider: 'KAKAO',
+    userId: 21,
+    username: 'james',
+    password: 'test1234!',
+    email: 'james@example.com',
+    nickname: '제임스',
+    profileImageName: 'Image2.png',
+    bio: '커피를 코드로 바꾸는 마법사',
+    links: ['james@example.com'],
+  },
+  {
+    provider: 'GOOGLE',
+    userId: 22,
+    username: 'edward',
+    password: 'test1234!',
+    email: 'edward@example.com',
+    nickname: '에드워드',
+    profileImageName: 'Image3.jpeg',
+    bio: '버그를 춤추게 하는 디버깅의 달인',
+    links: ['edward@example.com'],
+  },
+  {
+    provider: 'LOCAL',
+    userId: 23,
+    username: 'mary',
+    password: 'test1234!',
+    email: 'mary@example.com',
+    nickname: '메리',
+    profileImageName: 'Image4.jpg',
+    bio: '픽셀을 요리하는 디자인 셰프',
+    links: ['mary@example.com'],
+  },
+  {
+    provider: 'LOCAL',
+    userId: 24,
+    username: 'tom',
+    password: 'test1234!',
+    email: 'tom@example.com',
+    nickname: '톰',
+    profileImageName: 'Image5.jpeg',
+    bio: '알고리즘으로 세상을 정복하려는 꿈나무',
+    links: ['tom@example.com'],
+  },
+];
 
 // 역할 테이블 Mock
 export const ROLE_DUMMY: Role[] = [

--- a/src/mocks/mockData.ts
+++ b/src/mocks/mockData.ts
@@ -42,7 +42,7 @@ export const USER_DUMMY: UserInfo[] = [
   {
     userId: 1,
     username: 'panda_dev',
-    password: 'password1',
+    password: 'password@1',
     email: 'one@naver.com',
     provider: 'GOOGLE',
     nickname: '판다',
@@ -53,7 +53,7 @@ export const USER_DUMMY: UserInfo[] = [
   {
     userId: 2,
     username: 'chameleon_design',
-    password: 'password2',
+    password: 'password@2',
     email: 'two@naver.com',
     provider: 'KAKAO',
     nickname: '카멜레온',
@@ -64,7 +64,7 @@ export const USER_DUMMY: UserInfo[] = [
   {
     userId: 3,
     username: 'redpanda_front',
-    password: 'password3',
+    password: 'password@3',
     email: 'three@naver.com',
     provider: 'GOOGLE',
     nickname: '랫서판다',
@@ -75,7 +75,7 @@ export const USER_DUMMY: UserInfo[] = [
   {
     userId: 4,
     username: 'polar_bear_front',
-    password: 'password4',
+    password: 'password@4',
     email: 'four@naver.com',
     provider: 'KAKAO',
     nickname: '북금곰',
@@ -86,7 +86,7 @@ export const USER_DUMMY: UserInfo[] = [
   {
     userId: 5,
     username: 'tiger_backend',
-    password: 'password5',
+    password: 'password@5',
     email: 'five@naver.com',
     provider: 'KAKAO',
     nickname: '호랑이',
@@ -97,7 +97,7 @@ export const USER_DUMMY: UserInfo[] = [
   {
     userId: 6,
     username: 'sloth_fullstack',
-    password: 'password6',
+    password: 'password@6',
     email: 'six@naver.com',
     provider: 'GOOGLE',
     nickname: '나무늘보',
@@ -108,7 +108,7 @@ export const USER_DUMMY: UserInfo[] = [
   {
     userId: 7,
     username: 'wombat_backend',
-    password: 'password7',
+    password: 'password@7',
     email: 'seven@naver.com',
     provider: 'KAKAO',
     nickname: '웜뱃',
@@ -119,7 +119,7 @@ export const USER_DUMMY: UserInfo[] = [
   {
     userId: 8,
     username: 'beluga_design',
-    password: 'password8',
+    password: 'password@8',
     email: 'eight@naver.com',
     provider: 'GOOGLE',
     nickname: '벨루가',
@@ -130,7 +130,7 @@ export const USER_DUMMY: UserInfo[] = [
   {
     userId: 9,
     username: 'penguin_dba',
-    password: 'password9',
+    password: 'password@9',
     email: 'nine@naver.com',
     provider: 'KAKAO',
     nickname: '펭귄',
@@ -141,7 +141,7 @@ export const USER_DUMMY: UserInfo[] = [
   {
     userId: 10,
     username: 'beaver_devops',
-    password: 'password10',
+    password: 'password@10',
     email: 'ten@naver.com',
     provider: 'GOOGLE',
     nickname: '비버',
@@ -152,7 +152,7 @@ export const USER_DUMMY: UserInfo[] = [
   {
     userId: 11,
     username: 'eleven',
-    password: 'password11',
+    password: 'password@11',
     email: 'eleven@naver.com',
     provider: 'LOCAL',
     nickname: '판다아빠',
@@ -163,7 +163,7 @@ export const USER_DUMMY: UserInfo[] = [
   {
     userId: 12,
     username: 'twelve',
-    password: 'password12',
+    password: 'password@12',
     email: 'twelve@naver.com',
     provider: 'LOCAL',
     nickname: '판다엄마',
@@ -174,7 +174,7 @@ export const USER_DUMMY: UserInfo[] = [
   {
     userId: 13,
     username: 'thirteen',
-    password: 'password13',
+    password: 'password@13',
     email: 'thirteen@naver.com',
     provider: 'LOCAL',
     nickname: '판다형',
@@ -185,7 +185,7 @@ export const USER_DUMMY: UserInfo[] = [
   {
     userId: 14,
     username: 'fourteen',
-    password: 'password14',
+    password: 'password@14',
     email: 'fourteen@naver.com',
     provider: 'LOCAL',
     nickname: '판다누나',
@@ -196,7 +196,7 @@ export const USER_DUMMY: UserInfo[] = [
   {
     userId: 15,
     username: 'fifteen',
-    password: 'password15',
+    password: 'password@15',
     email: 'fifteen@naver.com',
     provider: 'LOCAL',
     nickname: '판다동생',

--- a/src/mocks/services/authServiceHandler.ts
+++ b/src/mocks/services/authServiceHandler.ts
@@ -79,9 +79,11 @@ const authServiceHandler = [
   }),
 
   // 액세스 토큰 갱신 API
-  http.post(`${BASE_URL}/user/refresh`, async ({ cookies }) => {
-    const { refreshToken, refreshTokenExpiresAt, accessToken } = cookies;
+  http.post(`${BASE_URL}/user/refresh`, async ({ cookies, request }) => {
+    const accessToken = request.headers.get('Authorization');
+    if (!accessToken) return new HttpResponse(null, { status: 401 });
 
+    const { refreshToken, refreshTokenExpiresAt } = cookies;
     const cookieRefreshToken = Cookies.get('refreshToken');
 
     if (!refreshToken || !refreshTokenExpiresAt) {
@@ -100,7 +102,7 @@ const authServiceHandler = [
       let newAccessToken;
 
       // ToDo: 추후 삭제
-      if (accessToken.split('')[1] === JWT_TOKEN_DUMMY) {
+      if (accessToken === JWT_TOKEN_DUMMY) {
         newAccessToken = 'newMockedAccessToken';
       } else {
         // 토큰에서 userId 추출하도록 수정
@@ -256,7 +258,6 @@ const authServiceHandler = [
 
     let userId;
     // ToDo: 추후 삭제
-    console.log(accessToken);
     if (accessToken === JWT_TOKEN_DUMMY) {
       const payload = JWT_TOKEN_DUMMY.split('.')[1];
       userId = Number(payload.replace('mocked-payload-', ''));

--- a/src/mocks/services/authServiceHandler.ts
+++ b/src/mocks/services/authServiceHandler.ts
@@ -3,6 +3,7 @@ import { http, HttpResponse } from 'msw';
 import { AUTH_SETTINGS } from '@constants/settings';
 import { emailVerificationCode, USER_INFO_DUMMY } from '@mocks/mockData';
 import {
+  CheckNicknameForm,
   EmailVerificationForm,
   RequestEmailCode,
   SearchPasswordForm,
@@ -14,6 +15,17 @@ const BASE_URL = import.meta.env.VITE_BASE_URL;
 const refreshTokenExpiryDate = new Date(Date.now() + AUTH_SETTINGS.REFRESH_TOKEN_EXPIRATION).toISOString();
 
 const authServiceHandler = [
+  // 닉네임 중복 확인 API
+  http.post(`${BASE_URL}/user/nickname`, async ({ request }) => {
+    const { nickname } = (await request.json()) as CheckNicknameForm;
+
+    if (nickname === USER_INFO_DUMMY.nickname) {
+      return HttpResponse.json({ message: '사용할 수 없는 닉네임입니다.' }, { status: 400 });
+    }
+
+    return HttpResponse.json(null, { status: 200 });
+  }),
+
   // 로그인 API
   http.post(`${BASE_URL}/user/login`, async ({ request }) => {
     const { username, password } = (await request.json()) as UserSignInForm;

--- a/src/mocks/services/authServiceHandler.ts
+++ b/src/mocks/services/authServiceHandler.ts
@@ -31,7 +31,11 @@ const authServiceHandler = [
     }
 
     const existingUser = USER_DUMMY.find((user) => user.email === email);
-    if (existingUser) return HttpResponse.json({ message: '해당 이메일을 사용할 수 없습니다.' }, { status: 400 });
+    if (existingUser)
+      return HttpResponse.json(
+        { message: '해당 이메일을 사용할 수 없습니다. 다른 이메일을 등록해 주세요.' },
+        { status: 400 },
+      );
 
     const newUser: UserInfo = {
       userId: USER_DUMMY.length + 1,

--- a/src/pages/setting/UserSettingPage.tsx
+++ b/src/pages/setting/UserSettingPage.tsx
@@ -3,7 +3,6 @@ import { USER_AUTH_VALIDATION_RULES } from '@constants/formValidationRules';
 import ValidationInput from '@components/common/ValidationInput';
 import ProfileImageContainer from '@components/user/auth-form/ProfileImageContainer';
 import LinkContainer from '@components/user/auth-form/LinkContainer';
-import { USER_INFO_DUMMY } from '@mocks/mockData';
 import { useStore } from '@stores/useStore';
 import type { EditUserInfoForm } from '@/types/UserType';
 
@@ -82,7 +81,7 @@ export default function UserSettingPage() {
           </section>
 
           {/* 링크 */}
-          <LinkContainer initialLinks={USER_INFO_DUMMY.links} />
+          <LinkContainer initialLinks={userInfoData.links} />
 
           {/* 개인정보 수정 버튼 */}
           <button

--- a/src/pages/user/SignUpPage.tsx
+++ b/src/pages/user/SignUpPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { AxiosError } from 'axios';
 import { Link, useNavigate } from 'react-router-dom';
@@ -32,9 +32,15 @@ export default function SignUpPage() {
   });
 
   const { watch, handleSubmit, formState, register } = methods;
+  const nickname = watch('nickname');
 
+  // 중복 확인 후 닉네임 변경 시, 중복확인 버튼 재활성화
+  useEffect(() => {
+    if (formState.dirtyFields.nickname) setCheckedNickname(false);
+  }, [nickname, formState.dirtyFields.nickname]);
+
+  // ToDo: 유저 설정 페이지에 적용하며 분리
   const checkNickname = async () => {
-    const nickname = watch('nickname');
     if (!nickname || formState.errors.nickname) return;
 
     try {
@@ -100,6 +106,7 @@ export default function SignUpPage() {
           register={register('nickname', USER_AUTH_VALIDATION_RULES.NICKNAME)}
           isButtonInput
           buttonLabel="중복확인"
+          buttonDisabled={checkedNickname}
           onButtonClick={checkNickname}
         />
 

--- a/src/pages/user/SignUpPage.tsx
+++ b/src/pages/user/SignUpPage.tsx
@@ -1,5 +1,5 @@
 import { FormProvider, useForm } from 'react-hook-form';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { Link } from 'react-router-dom';
 import { USER_AUTH_VALIDATION_RULES } from '@constants/formValidationRules';
 import ValidationInput from '@components/common/ValidationInput';
@@ -7,6 +7,7 @@ import VerificationButton from '@components/user/auth-form/VerificationButton';
 import LinkContainer from '@components/user/auth-form/LinkContainer';
 import useToast from '@hooks/useToast';
 import useEmailVerification from '@hooks/useEmailVerification';
+import { checkNicknameDuplicate } from '@services/authService';
 import type { UserSignUpForm } from '@/types/UserType';
 
 export default function SignUpPage() {
@@ -27,6 +28,21 @@ export default function SignUpPage() {
     },
   });
 
+  const { watch, handleSubmit, formState, register } = methods;
+
+  const checkNickname = async () => {
+    const nickname = watch('nickname');
+    if (!nickname || formState.errors.nickname) return;
+
+    try {
+      await checkNicknameDuplicate({ nickname });
+      toastSuccess('사용 가능한 닉네임입니다.');
+    } catch (error) {
+      if (error instanceof AxiosError && error.response) toastError(error.response.data.message);
+      else toastError('예상치 못한 에러가 발생했습니다.');
+    }
+  };
+
   // form 전송 함수
   const onSubmit = async (data: UserSignUpForm) => {
     const { username, code, checkPassword, ...filteredData } = data;
@@ -44,54 +60,52 @@ export default function SignUpPage() {
 
   return (
     <FormProvider {...methods}>
-      <form onSubmit={methods.handleSubmit(onSubmit)} className="flex w-300 grow flex-col justify-center gap-8">
+      <form onSubmit={handleSubmit(onSubmit)} className="flex w-300 grow flex-col justify-center gap-8">
         {/* 아이디 */}
         <ValidationInput
           label="아이디"
-          errors={methods.formState.errors?.username?.message}
-          register={methods.register('username', USER_AUTH_VALIDATION_RULES.ID)}
+          errors={formState.errors?.username?.message}
+          register={register('username', USER_AUTH_VALIDATION_RULES.ID)}
         />
 
         {/* 이메일 */}
         <ValidationInput
           label="이메일"
-          errors={methods.formState.errors.email?.message}
-          register={methods.register('email', USER_AUTH_VALIDATION_RULES.EMAIL)}
+          errors={formState.errors.email?.message}
+          register={register('email', USER_AUTH_VALIDATION_RULES.EMAIL)}
         />
 
         {isVerificationRequested && (
           <ValidationInput
             label="인증번호"
-            errors={methods.formState.errors.code?.message}
-            register={methods.register('code', USER_AUTH_VALIDATION_RULES.CERTIFICATION)}
+            errors={formState.errors.code?.message}
+            register={register('code', USER_AUTH_VALIDATION_RULES.CERTIFICATION)}
           />
         )}
 
         {/* 닉네임, 중복 확인 */}
         <ValidationInput
           label="닉네임"
-          errors={methods.formState.errors.nickname?.message}
-          register={methods.register('nickname', USER_AUTH_VALIDATION_RULES.NICKNAME)}
+          errors={formState.errors.nickname?.message}
+          register={register('nickname', USER_AUTH_VALIDATION_RULES.NICKNAME)}
           isButtonInput
           buttonLabel="중복확인"
+          onButtonClick={checkNickname}
         />
 
         {/* 비밀번호 */}
         <ValidationInput
           label="비밀번호"
-          errors={methods.formState.errors.password?.message}
-          register={methods.register('password', USER_AUTH_VALIDATION_RULES.PASSWORD)}
+          errors={formState.errors.password?.message}
+          register={register('password', USER_AUTH_VALIDATION_RULES.PASSWORD)}
           type="password"
         />
 
         {/* 비밀번호 확인 */}
         <ValidationInput
           label="비밀번호 확인"
-          errors={methods.formState.errors.checkPassword?.message}
-          register={methods.register(
-            'checkPassword',
-            USER_AUTH_VALIDATION_RULES.PASSWORD_CONFIRM(methods.watch('password')),
-          )}
+          errors={formState.errors.checkPassword?.message}
+          register={register('checkPassword', USER_AUTH_VALIDATION_RULES.PASSWORD_CONFIRM(watch('password')))}
           type="password"
         />
 
@@ -101,7 +115,7 @@ export default function SignUpPage() {
             자기소개
           </label>
           <textarea
-            {...methods.register('bio')}
+            {...register('bio')}
             id="bio"
             placeholder="ex) 안녕하세요. 홍길동입니다."
             className="block h-70 w-full resize-none rounded-lg border border-input p-8 text-sm outline-none placeholder:text-emphasis"
@@ -115,8 +129,8 @@ export default function SignUpPage() {
         <div className="space-y-8 text-center">
           <VerificationButton
             isVerificationRequested={isVerificationRequested}
-            isSubmitting={methods.formState.isSubmitting}
-            requestCode={methods.handleSubmit(() => requestVerificationCode(methods.watch('email')))}
+            isSubmitting={formState.isSubmitting}
+            requestCode={handleSubmit(() => requestVerificationCode(watch('email')))}
             expireVerificationCode={expireVerificationCode}
             buttonLabel="회원가입"
           />

--- a/src/pages/user/SignUpPage.tsx
+++ b/src/pages/user/SignUpPage.tsx
@@ -1,5 +1,6 @@
+import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-import axios, { AxiosError } from 'axios';
+import { AxiosError } from 'axios';
 import { Link, useNavigate } from 'react-router-dom';
 import { USER_AUTH_VALIDATION_RULES } from '@constants/formValidationRules';
 import ValidationInput from '@components/common/ValidationInput';
@@ -8,7 +9,6 @@ import LinkContainer from '@components/user/auth-form/LinkContainer';
 import useToast from '@hooks/useToast';
 import useEmailVerification from '@hooks/useEmailVerification';
 import { checkNicknameDuplicate, signUp } from '@services/authService';
-import { useState } from 'react';
 import type { UserSignUpForm } from '@/types/UserType';
 
 export default function SignUpPage() {
@@ -22,7 +22,7 @@ export default function SignUpPage() {
     defaultValues: {
       username: null,
       email: '',
-      code: '',
+      verificationCode: '',
       nickname: '',
       password: '',
       checkPassword: '',
@@ -88,8 +88,8 @@ export default function SignUpPage() {
         {isVerificationRequested && (
           <ValidationInput
             label="인증번호"
-            errors={formState.errors.code?.message}
-            register={register('code', USER_AUTH_VALIDATION_RULES.CERTIFICATION)}
+            errors={formState.errors.verificationCode?.message}
+            register={register('verificationCode', USER_AUTH_VALIDATION_RULES.VERIFICATION_CODE)}
           />
         )}
 

--- a/src/pages/user/SignUpPage.tsx
+++ b/src/pages/user/SignUpPage.tsx
@@ -31,7 +31,7 @@ export default function SignUpPage() {
     },
   });
 
-  const { watch, handleSubmit, formState, register } = methods;
+  const { watch, handleSubmit, formState, register, setValue } = methods;
   const nickname = watch('nickname');
 
   // 중복 확인 후 닉네임 변경 시, 중복확인 버튼 재활성화
@@ -62,6 +62,7 @@ export default function SignUpPage() {
   const onSubmit = async (data: UserSignUpForm) => {
     const { checkPassword, ...filteredData } = data;
 
+    // ToDo: useAxios 훅을 이용한 네트워크 로직으로 변경
     try {
       await signUp(filteredData);
       toastSuccess('회원가입에 성공했습니다. 로그인을 진행해 주세요.');
@@ -69,8 +70,16 @@ export default function SignUpPage() {
         navigate('/signin');
       }, 2000);
     } catch (error) {
-      if (error instanceof AxiosError && error.response) toastError(error.response.data.message);
-      else toastError('예상치 못한 에러가 발생했습니다.');
+      if (error instanceof AxiosError && error.response) {
+        toastError(error.response.data.message);
+        if (
+          error.response.status === 400 &&
+          error.response.data.message.includes('해당 이메일을 사용할 수 없습니다.')
+        ) {
+          expireVerificationCode(false);
+          setValue('verificationCode', '');
+        }
+      } else toastError('예상치 못한 에러가 발생했습니다.');
     }
   };
 

--- a/src/pages/user/SignUpPage.tsx
+++ b/src/pages/user/SignUpPage.tsx
@@ -4,11 +4,9 @@ import { Link } from 'react-router-dom';
 import { USER_AUTH_VALIDATION_RULES } from '@constants/formValidationRules';
 import ValidationInput from '@components/common/ValidationInput';
 import VerificationButton from '@components/user/auth-form/VerificationButton';
-import ProfileImageContainer from '@components/user/auth-form/ProfileImageContainer';
 import LinkContainer from '@components/user/auth-form/LinkContainer';
 import useToast from '@hooks/useToast';
 import useEmailVerification from '@hooks/useEmailVerification';
-import reduceImageSize from '@utils/reduceImageSize';
 import type { UserSignUpForm } from '@/types/UserType';
 
 export default function SignUpPage() {
@@ -26,42 +24,19 @@ export default function SignUpPage() {
       checkPassword: '',
       bio: null,
       links: [],
-      profileImageName: null,
     },
   });
 
   // form 전송 함수
   const onSubmit = async (data: UserSignUpForm) => {
-    const { username, code, checkPassword, profileImageName, ...filteredData } = data;
+    const { username, code, checkPassword, ...filteredData } = data;
     console.log(data);
     // TODO: 폼 제출 로직 수정 필요
     try {
       // 회원가입 폼
-      const formData = { ...filteredData, username, code, profileImageName };
+      const formData = { ...filteredData, username, code };
       const registrationResponse = await axios.post(`http://localhost:8080/api/v1/user/${username}`, formData);
       if (registrationResponse.status !== 200) return toastError('회원가입에 실패했습니다. 다시 시도해 주세요.');
-
-      // 이미지 폼
-      if (!methods.watch('profileImageName')) return toastSuccess('회원가입이 완료되었습니다.');
-      const imgFormData = new FormData();
-      try {
-        if (!profileImageName) return;
-
-        const jpeg = await reduceImageSize(profileImageName);
-        const file = new File([jpeg], new Date().toISOString(), { type: 'image/jpeg' });
-        imgFormData.append('profileImageName', file);
-        imgFormData.append('username', username ?? '');
-
-        const imageResponse = await axios.post(`http://localhost:8080/api/v1/users/file`, imgFormData, {
-          headers: { 'Content-Type': 'multipart/form-data' },
-        });
-
-        if (imageResponse.status !== 200) return toastError('이미지 업로드에 실패했습니다. 다시 시도해 주세요.');
-
-        toastSuccess('회원가입이 완료되었습니다.');
-      } catch (err) {
-        toastError(`이미지 업로드에 실패했습니다: ${err}`);
-      }
     } catch (error) {
       toastError(`회원가입 진행 중 오류가 발생했습니다: ${error}`);
     }
@@ -69,13 +44,7 @@ export default function SignUpPage() {
 
   return (
     <FormProvider {...methods}>
-      <form onSubmit={methods.handleSubmit(onSubmit)} className="w-300 space-y-8">
-        {/* 프로필 이미지 */}
-        <ProfileImageContainer
-          imageUrl={methods.watch('profileImageName')}
-          setImageUrl={(url: string) => methods.setValue('profileImageName', url)}
-        />
-
+      <form onSubmit={methods.handleSubmit(onSubmit)} className="flex w-300 grow flex-col justify-center gap-8">
         {/* 아이디 */}
         <ValidationInput
           label="아이디"

--- a/src/pages/user/SignUpPage.tsx
+++ b/src/pages/user/SignUpPage.tsx
@@ -20,7 +20,7 @@ export default function SignUpPage() {
   const methods = useForm<UserSignUpForm>({
     mode: 'onChange',
     defaultValues: {
-      username: null,
+      username: '',
       email: '',
       verificationCode: '',
       nickname: '',

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -11,7 +11,21 @@ import type {
   UserSignInForm,
   UpdatePasswordRequest,
   CheckNicknameForm,
+  UserSignUpRequest,
 } from '@/types/UserType';
+
+/**
+ * 회원가입 API
+ *
+ * @export
+ * @async
+ * @param {UserSignUpRequest} signUpForm  - 회원가입 폼 데이터
+ * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
+ * @returns {Promise<AxiosResponse>}
+ */
+export async function signUp(signUpForm: UserSignUpRequest, axiosConfig: AxiosRequestConfig = {}) {
+  return defaultAxios.post('user', signUpForm, axiosConfig);
+}
 
 /**
  * 닉네임 중복 확인 API

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -10,7 +10,21 @@ import type {
   User,
   UserSignInForm,
   UpdatePasswordRequest,
+  CheckNicknameForm,
 } from '@/types/UserType';
+
+/**
+ * 닉네임 중복 확인 API
+ *
+ * @export
+ * @async
+ * @param {CheckNicknameForm} nicknameForm - 닉네임
+ * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
+ * @returns {Promise<AxiosResponse>}
+ */
+export async function checkNicknameDuplicate(nicknameForm: CheckNicknameForm, axiosConfig: AxiosRequestConfig = {}) {
+  return defaultAxios.post('user/nickname', nicknameForm, axiosConfig);
+}
 
 /**
  * 사용자 로그인 API

--- a/src/stores/useStore.ts
+++ b/src/stores/useStore.ts
@@ -76,7 +76,7 @@ const createUserSlice: StateCreator<Store, [], [], UserStore> = (set) => ({
   userInfo: {
     provider: 'LOCAL',
     userId: 0,
-    username: null,
+    username: '',
     email: '',
     nickname: '',
     bio: null,
@@ -93,7 +93,7 @@ const createUserSlice: StateCreator<Store, [], [], UserStore> = (set) => ({
       userInfo: {
         provider: 'LOCAL',
         userId: 0,
-        username: null,
+        username: '',
         email: '',
         nickname: '',
         bio: null,

--- a/src/types/UserType.tsx
+++ b/src/types/UserType.tsx
@@ -22,6 +22,8 @@ export type UserSignUpForm = Omit<User, 'userId' | 'provider' | 'profileImageNam
   checkPassword: string;
 };
 
+export type UserSignUpRequest = Omit<UserSignUpForm, 'checkPassword'>;
+
 export type CheckNicknameForm = Pick<User, 'nickname'>;
 
 export type UserSignInForm = Pick<User, 'username'> & {

--- a/src/types/UserType.tsx
+++ b/src/types/UserType.tsx
@@ -2,13 +2,17 @@ import type { Role } from '@/types/RoleType';
 
 export type User = {
   userId: number;
-  username: string | null;
+  username: string;
   email: string;
   provider: 'LOCAL' | 'KAKAO' | 'GOOGLE';
   nickname: string;
   bio: string | null;
   links: string[];
   profileImageName: string | null;
+};
+
+export type UserInfo = User & {
+  password: string;
 };
 
 export type SearchUser = Pick<User, 'userId' | 'nickname'>;

--- a/src/types/UserType.tsx
+++ b/src/types/UserType.tsx
@@ -16,11 +16,13 @@ export type UserWithRole = SearchUser & Pick<Role, 'roleName'>;
 
 export type EditUserInfoForm = Omit<User, 'userId' | 'provider'>;
 
-export type UserSignUpForm = Omit<User, 'userId' | 'provider'> & {
+export type UserSignUpForm = Omit<User, 'userId' | 'provider' | 'profileImageName'> & {
   code: string;
   password: string;
   checkPassword: string;
 };
+
+export type CheckNicknameForm = Pick<User, 'nickname'>;
 
 export type UserSignInForm = Pick<User, 'username'> & {
   password: string;

--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -1,4 +1,4 @@
-import { fileSizeUnits } from '@/constants/units';
+import { fileSizeUnits } from '@constants/units';
 
 export function generatePrefixId(id: number | string, prefix: string, delimiter: string = '-') {
   return `${prefix}${delimiter}${id}`;
@@ -22,4 +22,46 @@ export const convertBytesToString = (bytes: number) => {
 export const generateSecureUserId = (id: string) => {
   const secureLength = id.length >= 4 ? 2 : 1;
   return `${id.slice(0, -secureLength)}${'*'.repeat(secureLength)}`;
+};
+
+export const generateDummyToken = (userId: number) => {
+  const header = { alg: 'none', typ: 'JWT' };
+  const payload = { userId };
+  const signature = 'mocked-signature';
+
+  const base64UrlEncode = (obj: object) => {
+    const jsonString = JSON.stringify(obj);
+    // 일반 Base64 인코딩
+    const base64 = btoa(decodeURIComponent(encodeURIComponent(jsonString)));
+    // URL-safe 변환: `+` -> `-`, `/` -> `_`, `=` 제거
+    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  };
+
+  const base64UrlHeader = base64UrlEncode(header);
+  const base64UrlPayload = base64UrlEncode(payload);
+
+  return `${base64UrlHeader}.${base64UrlPayload}.${signature}`;
+};
+
+export const convertTokenToUserId = (accessToken: string) => {
+  const tokenParts = accessToken.split('.');
+  if (tokenParts.length !== 3) return 0;
+
+  const payload = tokenParts[1];
+
+  // base64url 디코딩을 위한 처리
+  const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+  const padding = '='.repeat((4 - (base64.length % 4)) % 4);
+  const base64WithPadding = base64 + padding;
+
+  try {
+    // base64 페이로드 디코딩
+    const decodedPayload = JSON.parse(atob(base64WithPadding));
+    const { userId } = decodedPayload;
+
+    return userId;
+  } catch (error) {
+    console.error('토큰 페이로드 디코딩 오류:', error);
+    return 0;
+  }
 };


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해 주세요. -->

- [x] **\[Feat\]** 새로운 기능을 추가했어요.
- [x] **\[UI\]** CSS 등 사용자 UI 디자인 추가/삭제/변경 했어요.
- [x] **\[Test\]** 테스트 코드를 추가/삭제/변경 했어요.
- [x] **\[Chore\]** 빌드 프로세스 변경, 의존성 패키지 업데이트 했어요.

## Related Issues

<!--#을 눌러 이슈와 연결해 주세요-->
#159 닉네임 중복 확인 API 및 회원가입 기능 구현

## What does this PR do?

<!--무엇을 하셨나요?-->

- [x] 닉네임 중복 확인 API 구현
- [x] 회원가입 기능 구현
- [x] MSW 테스트를 위한 유저 mock 데이터 추가, 타입 수정
- [x] userId를 통해 Mock JWT 생성 및 JWT의 payload를 디코딩해 userId를 추출하는 함수 추가  

## View
![회원가입](https://github.com/user-attachments/assets/7bb78213-5a3e-47bf-9e9f-482083bc854f)
mock데이터에 존재하지 않는 유저를 회원가입시키고, 로그인하는 과정입니다.

## Other information

<!--참고한 자료, 추가적인 사항, 기타 의견-->
- 닉네임 중복 확인 코드는 유저 설정 변경 페이지에서도 사용되기 때문에, 해당 작업을 하면서 분리하도록 하겠습니다.
- 로그인 시 userId를 이용해 JWT를 생성하고 이를 이용해 네트워크 요청을 하도록 MSW 쪽 코드를 수정했습니다.
- 다만, 아직 기존의 JWT 더미 데이터를 사용 중인 곳이 많아서 axiosProvider 쪽은 건드리지 않았습니다. 
- (제 쪽은 현재 유저의 userId를 사용해 JWT를 생성하고 있기는 하지만, axiosProvider를 수정하지 않았다 보니 새로고침을 하면 기존 JWT 더미 데이터의 유저 4번으로 사용자를 인식하고 있습니다.😂 msw 핸들러 내부의 `토큰에서 userId 추출` 관련 분기문이 보이신다면 그 부분을 처리해 준 내용입니다.)
- 따라서 다른 분들이 작업할 때는 기존처럼 JWT 더미 데이터를 사용해 테스트 진행하셔도 에러는 없을 것 같습니다. 그래도 혹시 모르니 네트워크 쪽 에러가 발생한다면 말씀해 주세요!
- 참고로, MSW에서는 아래와 같이 userId를 가져오도록 했습니다.
```ts
http.patch(`${BASE_URL}/user/password`, async ({ request }) => {
    const accessToken = request.headers.get('Authorization');
    if (!accessToken) return HttpResponse.json({ message: '인증 정보가 존재하지 않습니다.' }, { status: 401 });

   // 유저 ID 추출
    const userId = convertTokenToUserId(accessToken);
    if (userId === 0) return new HttpResponse(null, { status: 401 });

    const existingUser = USER_DUMMY.find((user) => user.userId === Number(userId));
    if (!existingUser) return HttpResponse.json({ message: '해당 사용자를 찾을 수 없습니다.' }, { status: 404 });
    ...
    return HttpResponse.json(null, { status: 200 });
  }),
```
- 폼의 버튼 disabled는 기능 구현이 끝난 뒤 전체 폼을 한번에 처리하도록 하겠습니다!