### PR TITLE
Feat: #188 일정 상세 모달 수정 버튼 기능 구현 (상세 모달 → 수정 모달 전환)

### DIFF
--- a/src/components/modal/task/DetailModalTask.tsx
+++ b/src/components/modal/task/DetailModalTask.tsx
@@ -18,10 +18,11 @@ import type { Project } from '@/types/ProjectType';
 type ViewModalTaskProps = {
   project: Project;
   task: Task;
+  openUpdateModal: () => void;
   onClose: () => void;
 };
 
-export default function DetailModalTask({ project, task, onClose: handleClose }: ViewModalTaskProps) {
+export default function DetailModalTask({ project, task, openUpdateModal, onClose: handleClose }: ViewModalTaskProps) {
   const { mutate: deleteTaskMutate } = useDeleteTask(project.projectId);
   const { status, isStatusLoading } = useReadStatuses(project.projectId, task.statusId);
   const { assigneeList, isAssigneeLoading } = useReadAssignees(project.projectId, task.taskId);
@@ -35,8 +36,10 @@ export default function DetailModalTask({ project, task, onClose: handleClose }:
     [startDate, endDate],
   );
 
-  // ToDo: 일정 수정 버튼 클릭시 처리 추가할 것
-  const handleUpdateClick = () => {};
+  const handleUpdateClick = () => {
+    openUpdateModal();
+    handleClose();
+  };
 
   // ToDo: 유저 권한 확인하는 로직 추가할 것
   const handleDeleteClick = (taskId: Task['taskId']) => deleteTaskMutate(taskId);

--- a/src/components/task/kanban/TaskItem.tsx
+++ b/src/components/task/kanban/TaskItem.tsx
@@ -5,6 +5,7 @@ import { DND_DRAGGABLE_PREFIX } from '@constants/dnd';
 import useModal from '@hooks/useModal';
 import useProjectContext from '@hooks/useProjectContext';
 import DetailModalTask from '@components/modal/task/DetailModalTask';
+import UpdateModalTask from '@components/modal/task/UpdateModalTask';
 import type { Task } from '@/types/TaskType';
 import type { ProjectStatus } from '@/types/ProjectStatusType';
 
@@ -15,13 +16,14 @@ type TaskItemProps = {
 
 export default function TaskItem({ task, colorCode }: TaskItemProps) {
   const { project } = useProjectContext();
-  const { showModal, openModal, closeModal } = useModal();
+  const { showModal: showDetailModal, openModal: openDetailModal, closeModal: closeDetailModal } = useModal();
+  const { showModal: showUpdateModal, openModal: openUpdateModal, closeModal: closeUpdateModal } = useModal();
 
   const { taskId, name, sortOrder } = task;
   const index = useMemo(() => sortOrder - 1, [sortOrder]);
   const draggableId = useMemo(() => generatePrefixId(taskId, DND_DRAGGABLE_PREFIX.TASK), [taskId]);
 
-  const handleTaskClick = () => openModal();
+  const handleTaskClick = () => openDetailModal();
 
   return (
     <>
@@ -42,7 +44,10 @@ export default function TaskItem({ task, colorCode }: TaskItemProps) {
           </div>
         )}
       </Draggable>
-      {showModal && <DetailModalTask project={project} task={task} onClose={closeModal} />}
+      {showDetailModal && (
+        <DetailModalTask project={project} task={task} openUpdateModal={openUpdateModal} onClose={closeDetailModal} />
+      )}
+      {showUpdateModal && <UpdateModalTask project={project} taskId={task.taskId} onClose={closeUpdateModal} />}
     </>
   );
 }

--- a/src/pages/project/CalendarPage.tsx
+++ b/src/pages/project/CalendarPage.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useMemo, useState } from 'react';
 import { DateTime, Settings } from 'luxon';
 import { Calendar, luxonLocalizer, Views } from 'react-big-calendar';
+import DetailModalTask from '@components/modal/task/DetailModalTask';
+import UpdateModalTask from '@components/modal/task/UpdateModalTask';
 import CalendarToolbar from '@components/task/calendar/CalendarToolbar';
 import CustomDateHeader from '@components/task/calendar/CustomDateHeader';
 import CustomEventWrapper from '@components/task/calendar/CustomEventWrapper';
-import UpdateModalTask from '@components/modal/task/UpdateModalTask';
 import useModal from '@hooks/useModal';
 import useProjectContext from '@hooks/useProjectContext';
 import { useReadStatusTasks } from '@hooks/query/useTaskQuery';
@@ -15,7 +16,6 @@ import '@/customReactBigCalendar.css';
 import type { DayPropGetter, EventPropGetter } from 'react-big-calendar';
 import type { Task, TaskListWithStatus, TaskWithStatus } from '@/types/TaskType';
 import type { CustomEvent } from '@/types/CustomEventType';
-import DetailModalTask from '@/components/modal/task/DetailModalTask';
 
 function getCalendarTask(statusTasks: TaskListWithStatus[]) {
   const calendarTasks: TaskWithStatus[] = [];

--- a/src/pages/project/KanbanPage.tsx
+++ b/src/pages/project/KanbanPage.tsx
@@ -9,6 +9,7 @@ import { useUpdateStatusesOrder } from '@hooks/query/useStatusQuery';
 import { useReadStatusTasks, useUpdateTasksOrder } from '@hooks/query/useTaskQuery';
 import type { Task, TaskListWithStatus } from '@/types/TaskType';
 
+// 상태 순서 변경
 function createChangedStatus(statusTasks: TaskListWithStatus[], dropResult: DropResult) {
   const { source, destination } = dropResult;
 
@@ -24,6 +25,7 @@ function createChangedStatus(statusTasks: TaskListWithStatus[], dropResult: Drop
   return newStatusTasks;
 }
 
+// 일정 순서 변경
 function createChangedTasks(statusTasks: TaskListWithStatus[], dropResult: DropResult, isSameStatus: boolean) {
   const { source, destination, draggableId } = dropResult;
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] **\[Feat\]** 새로운 기능을 추가했어요.

## Related Issues
- close #188

## What does this PR do?
- [x] 일정 상세 모달에서 수정 모달 전환을 위한 props 추가 (openUpdateModal) 
- [x] 칸반보드: 일정 상세 모달의 수정 버튼을 통해 수정 모달로 전환
- [x] 캘린더: 일정 상세 모달의 수정 버튼을 통해 수정 모달로 전환

## Other information
이전에 타입 수정으로 인해 Calendar 페이지에서 타입 호환 문제가 있는 것 같습니다. 이는 다음 PR에서 처리하도록 하겠습니다.

## View
**캘린더에서의 수정 모달 전환**
![화면 예시 - 캘린더 수정 모달 전환](https://github.com/user-attachments/assets/4bd7ff00-5305-428b-9f5e-55271e0e2696)

**칸반보드에서의 수정 모달 전환**
![화면 예시 - 칸반보드 수정 모달 전환](https://github.com/user-attachments/assets/25b4904e-4f7a-47fd-91fa-2914eaae4e4c)