### PR TITLE
Feat: #204 일정 수정 모달에서 일정 상세 모달로 돌아가기 버튼 추가

### DIFF
--- a/src/components/modal/ModalButton.tsx
+++ b/src/components/modal/ModalButton.tsx
@@ -1,17 +1,18 @@
 type ModalButtonProps = React.PropsWithChildren<{
   formId?: string;
+  color: 'text-white' | 'text-emphasis' | 'text-default';
   backgroundColor: 'bg-main' | 'bg-delete' | 'bg-sub' | 'bg-button' | 'bg-kakao';
   onClick?: () => void;
 }>;
 
-export default function ModalButton({ formId, backgroundColor, onClick, children }: ModalButtonProps) {
+export default function ModalButton({ formId, color, backgroundColor, onClick, children }: ModalButtonProps) {
   const handleClick = () => onClick && onClick();
 
   return (
     <button
       type={formId ? 'submit' : 'button'}
       form={formId}
-      className={`h-25 w-full rounded-md px-10 text-white outline-none ${backgroundColor} hover:brightness-90`}
+      className={`h-25 w-full rounded-md px-10 font-bold outline-none ${color} ${backgroundColor} hover:brightness-90`}
       onClick={handleClick}
     >
       {children}

--- a/src/components/modal/project-status/CreateModalProjectStatus.tsx
+++ b/src/components/modal/project-status/CreateModalProjectStatus.tsx
@@ -27,7 +27,7 @@ export default function CreateModalProjectStatus({ project, onClose: handleClose
     <ModalPortal>
       <ModalLayout onClose={handleClose}>
         <ModalProjectStatusForm formId={createStatusFormId} project={project} onSubmit={handleSubmit} />
-        <ModalButton formId={createStatusFormId} backgroundColor="bg-main">
+        <ModalButton formId={createStatusFormId} color="text-white" backgroundColor="bg-main">
           등록
         </ModalButton>
       </ModalLayout>

--- a/src/components/modal/project-status/UpdateModalProjectStatus.tsx
+++ b/src/components/modal/project-status/UpdateModalProjectStatus.tsx
@@ -61,10 +61,10 @@ export default function UpdateModalProjectStatus({
               onSubmit={handleSubmit}
             />
             <div className="flex min-h-25 w-4/5 gap-10">
-              <ModalButton formId={updateStatusFormId} backgroundColor="bg-main">
+              <ModalButton formId={updateStatusFormId} color="text-white" backgroundColor="bg-main">
                 수정
               </ModalButton>
-              <ModalButton backgroundColor="bg-delete" onClick={() => handleDeleteClick(statusId)}>
+              <ModalButton color="text-white" backgroundColor="bg-delete" onClick={() => handleDeleteClick(statusId)}>
                 삭제
               </ModalButton>
             </div>

--- a/src/components/modal/project/CreateModalProject.tsx
+++ b/src/components/modal/project/CreateModalProject.tsx
@@ -22,7 +22,7 @@ export default function CreateModalProject({ onClose: handleClose }: CreateModal
     <ModalPortal>
       <ModalLayout onClose={handleClose}>
         <ModalProjectForm formId={createProjectFormId} onSubmit={handleSubmit} />
-        <ModalButton formId={createProjectFormId} backgroundColor="bg-main">
+        <ModalButton formId={createProjectFormId} color="text-white" backgroundColor="bg-main">
           등록
         </ModalButton>
       </ModalLayout>

--- a/src/components/modal/project/UpdateModalProject.tsx
+++ b/src/components/modal/project/UpdateModalProject.tsx
@@ -27,7 +27,12 @@ export default function UpdateModalProject({ projectId, onClose: handleClose }: 
     <ModalPortal>
       <ModalLayout onClose={handleClose}>
         <ModalProjectForm formId={updateProjectFormId} projectId={projectId} onSubmit={handleSubmit} />
-        <ModalButton formId={updateProjectFormId} backgroundColor="bg-main" onClick={handleUpdateClick}>
+        <ModalButton
+          formId={updateProjectFormId}
+          color="text-white"
+          backgroundColor="bg-main"
+          onClick={handleUpdateClick}
+        >
           수정
         </ModalButton>
       </ModalLayout>

--- a/src/components/modal/task/CreateModalTask.tsx
+++ b/src/components/modal/task/CreateModalTask.tsx
@@ -48,7 +48,7 @@ export default function CreateModalTask({ project, onClose: handleClose }: Creat
     <ModalPortal>
       <ModalLayout onClose={handleClose}>
         <ModalTaskForm formId={createTaskFormId} project={project} onSubmit={handleSubmit} />
-        <ModalButton formId={createTaskFormId} backgroundColor="bg-main">
+        <ModalButton formId={createTaskFormId} color="text-white" backgroundColor="bg-main">
           등록
         </ModalButton>
       </ModalLayout>

--- a/src/components/modal/task/DetailModalTask.tsx
+++ b/src/components/modal/task/DetailModalTask.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { LuDownload } from 'react-icons/lu';
 import ModalPortal from '@components/modal/ModalPortal';
 import ModalLayout from '@layouts/ModalLayout';
@@ -10,31 +9,38 @@ import { downloadTaskFile } from '@services/taskService';
 import useAxios from '@hooks/useAxios';
 import useToast from '@hooks/useToast';
 import { useReadStatuses } from '@hooks/query/useStatusQuery';
-import { useDeleteTask, useReadAssignees, useReadTaskFiles } from '@hooks/query/useTaskQuery';
+import { useDeleteTask, useReadAssignees, useReadStatusTasks, useReadTaskFiles } from '@hooks/query/useTaskQuery';
 
 import type { Task } from '@/types/TaskType';
 import type { Project } from '@/types/ProjectType';
+import type { ProjectStatus } from '@/types/ProjectStatusType';
 
 type ViewModalTaskProps = {
-  project: Project;
-  task: Task;
+  projectId: Project['projectId'];
+  statusId: ProjectStatus['statusId'];
+  taskId: Task['taskId'];
   openUpdateModal: () => void;
   onClose: () => void;
 };
 
-export default function DetailModalTask({ project, task, openUpdateModal, onClose: handleClose }: ViewModalTaskProps) {
-  const { mutate: deleteTaskMutate } = useDeleteTask(project.projectId);
-  const { status, isStatusLoading } = useReadStatuses(project.projectId, task.statusId);
-  const { assigneeList, isAssigneeLoading } = useReadAssignees(project.projectId, task.taskId);
-  const { taskFileList, isTaskFileLoading } = useReadTaskFiles(project.projectId, task.taskId);
+export default function DetailModalTask({
+  projectId,
+  statusId,
+  taskId,
+  openUpdateModal,
+  onClose: handleClose,
+}: ViewModalTaskProps) {
+  const { mutate: deleteTaskMutate } = useDeleteTask(projectId);
+  const { status, isStatusLoading } = useReadStatuses(projectId, statusId);
+  const { task, isTaskLoading } = useReadStatusTasks(projectId, taskId);
+  const { assigneeList, isAssigneeLoading } = useReadAssignees(projectId, taskId);
+  const { taskFileList, isTaskFileLoading } = useReadTaskFiles(projectId, taskId);
   const { fetchData } = useAxios(downloadTaskFile);
   const { toastError } = useToast();
 
-  const { taskName, startDate, endDate } = task;
-  const period = useMemo(
-    () => (endDate && startDate !== endDate ? `${startDate} - ${endDate}` : startDate),
-    [startDate, endDate],
-  );
+  const getTaskPeriod = ({ startDate, endDate }: Task) => {
+    return endDate && startDate !== endDate ? `${startDate} - ${endDate}` : startDate;
+  };
 
   const handleUpdateClick = () => {
     openUpdateModal();
@@ -45,7 +51,7 @@ export default function DetailModalTask({ project, task, openUpdateModal, onClos
   const handleDeleteClick = (taskId: Task['taskId']) => deleteTaskMutate(taskId);
 
   const handleDownloadClick = async (originName: string, uploadName: string) => {
-    const response = await fetchData(project.projectId, task.taskId, uploadName);
+    const response = await fetchData(projectId, taskId, uploadName);
     if (response == null) return toastError('파일 다운로드 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.');
 
     const blob = new Blob([response.data], { type: response.headers['content-type'] });
@@ -64,7 +70,7 @@ export default function DetailModalTask({ project, task, openUpdateModal, onClos
   return (
     <ModalPortal>
       <ModalLayout onClose={handleClose}>
-        {isStatusLoading || isAssigneeLoading || isTaskFileLoading ? (
+        {isStatusLoading || isTaskLoading || isAssigneeLoading || isTaskFileLoading || !task ? (
           <Spinner />
         ) : (
           <article className="flex h-full flex-col justify-center gap-20">
@@ -77,11 +83,11 @@ export default function DetailModalTask({ project, task, openUpdateModal, onClos
               </div>
               <div className="flex gap-10">
                 <h2 className="w-50 shrink-0 text-large font-bold">일정명</h2>
-                <span>{taskName}</span>
+                <span>{task.taskName}</span>
               </div>
               <div className="flex gap-10">
                 <h2 className="w-50 shrink-0 text-large font-bold">기간</h2>
-                <span>{period}</span>
+                <span>{getTaskPeriod(task)}</span>
               </div>
               <div className="flex gap-10">
                 <h2 className="w-50 shrink-0 text-large font-bold">수행자</h2>
@@ -122,11 +128,7 @@ export default function DetailModalTask({ project, task, openUpdateModal, onClos
               <ModalButton color="text-white" backgroundColor="bg-main" onClick={handleUpdateClick}>
                 수정
               </ModalButton>
-              <ModalButton
-                color="text-white"
-                backgroundColor="bg-delete"
-                onClick={() => handleDeleteClick(task.taskId)}
-              >
+              <ModalButton color="text-white" backgroundColor="bg-delete" onClick={() => handleDeleteClick(taskId)}>
                 삭제
               </ModalButton>
             </div>

--- a/src/components/modal/task/DetailModalTask.tsx
+++ b/src/components/modal/task/DetailModalTask.tsx
@@ -119,10 +119,14 @@ export default function DetailModalTask({ project, task, openUpdateModal, onClos
               )}
             </section>
             <div className="flex min-h-25 gap-10">
-              <ModalButton backgroundColor="bg-main" onClick={handleUpdateClick}>
+              <ModalButton color="text-white" backgroundColor="bg-main" onClick={handleUpdateClick}>
                 수정
               </ModalButton>
-              <ModalButton backgroundColor="bg-delete" onClick={() => handleDeleteClick(task.taskId)}>
+              <ModalButton
+                color="text-white"
+                backgroundColor="bg-delete"
+                onClick={() => handleDeleteClick(task.taskId)}
+              >
                 삭제
               </ModalButton>
             </div>

--- a/src/components/modal/task/UpdateModalTask.tsx
+++ b/src/components/modal/task/UpdateModalTask.tsx
@@ -38,10 +38,16 @@ import type { ProjectSearchCallback } from '@/types/SearchCallbackType';
 type UpdateModalTaskProps = {
   project: Project;
   taskId: Task['taskId'];
+  openDetailModal: () => void;
   onClose: () => void;
 };
 
-export default function UpdateModalTask({ project, taskId, onClose: handleClose }: UpdateModalTaskProps) {
+export default function UpdateModalTask({
+  project,
+  taskId,
+  openDetailModal,
+  onClose: handleClose,
+}: UpdateModalTaskProps) {
   const updateTaskFormId = 'updateTaskForm';
   const { projectId, startDate, endDate } = project;
 
@@ -128,6 +134,11 @@ export default function UpdateModalTask({ project, taskId, onClose: handleClose 
 
   const handleFormSubmit: SubmitHandler<TaskUpdateForm> = async (formData) => updateTaskInfoMutate(formData);
 
+  const handleDetailClick = () => {
+    openDetailModal();
+    handleClose();
+  };
+
   return (
     <ModalPortal>
       <ModalLayout onClose={handleClose}>
@@ -203,7 +214,7 @@ export default function UpdateModalTask({ project, taskId, onClose: handleClose 
             onFileDeleteClick={handleFileDeleteClick}
           />
         )}
-        <ModalButton color="text-emphasis" backgroundColor="bg-button">
+        <ModalButton color="text-emphasis" backgroundColor="bg-button" onClick={handleDetailClick}>
           돌아가기
         </ModalButton>
       </ModalLayout>

--- a/src/components/modal/task/UpdateModalTask.tsx
+++ b/src/components/modal/task/UpdateModalTask.tsx
@@ -205,18 +205,20 @@ export default function UpdateModalTask({
         {isTaskFileLoading ? (
           <Spinner />
         ) : (
-          <FileDropZone
-            id="files"
-            label="첨부파일"
-            files={taskFileList}
-            accept={TASK_SETTINGS.FILE_ACCEPT}
-            updateFiles={updateTaskFiles}
-            onFileDeleteClick={handleFileDeleteClick}
-          />
+          <section className="space-y-20">
+            <FileDropZone
+              id="files"
+              label="첨부파일"
+              files={taskFileList}
+              accept={TASK_SETTINGS.FILE_ACCEPT}
+              updateFiles={updateTaskFiles}
+              onFileDeleteClick={handleFileDeleteClick}
+            />
+            <ModalButton color="text-emphasis" backgroundColor="bg-button" onClick={handleDetailClick}>
+              돌아가기
+            </ModalButton>
+          </section>
         )}
-        <ModalButton color="text-emphasis" backgroundColor="bg-button" onClick={handleDetailClick}>
-          돌아가기
-        </ModalButton>
       </ModalLayout>
     </ModalPortal>
   );

--- a/src/components/modal/task/UpdateModalTask.tsx
+++ b/src/components/modal/task/UpdateModalTask.tsx
@@ -126,10 +126,8 @@ export default function UpdateModalTask({ project, taskId, onClose: handleClose 
     return <Spinner />;
   }
 
-  const handleFormSubmit: SubmitHandler<TaskUpdateForm> = async (formData) => {
-    updateTaskInfoMutate(formData);
-    handleClose();
-  };
+  const handleFormSubmit: SubmitHandler<TaskUpdateForm> = async (formData) => updateTaskInfoMutate(formData);
+
   return (
     <ModalPortal>
       <ModalLayout onClose={handleClose}>

--- a/src/components/modal/task/UpdateModalTask.tsx
+++ b/src/components/modal/task/UpdateModalTask.tsx
@@ -166,7 +166,7 @@ export default function UpdateModalTask({ project, taskId, onClose: handleClose 
                 <MarkdownEditor id="content" label="내용" contentFieldName="content" />
               </form>
             </FormProvider>
-            <ModalButton formId={updateTaskFormId} backgroundColor="bg-main">
+            <ModalButton formId={updateTaskFormId} color="text-white" backgroundColor="bg-main">
               수정
             </ModalButton>
           </>
@@ -203,6 +203,9 @@ export default function UpdateModalTask({ project, taskId, onClose: handleClose 
             onFileDeleteClick={handleFileDeleteClick}
           />
         )}
+        <ModalButton color="text-emphasis" backgroundColor="bg-button">
+          돌아가기
+        </ModalButton>
       </ModalLayout>
     </ModalPortal>
   );

--- a/src/components/modal/team/CreateModalTeam.tsx
+++ b/src/components/modal/team/CreateModalTeam.tsx
@@ -24,7 +24,7 @@ export default function CreateModalTeam({ onClose: handleClose }: CreateModalPro
     <ModalPortal>
       <ModalLayout onClose={handleClose}>
         <ModalTeamForm formId={createTeamFormId} onSubmit={handleSubmit} />
-        <ModalButton formId={createTeamFormId} backgroundColor="bg-main">
+        <ModalButton formId={createTeamFormId} color="text-white" backgroundColor="bg-main">
           등록
         </ModalButton>
       </ModalLayout>

--- a/src/components/modal/team/UpdateModalTeam.tsx
+++ b/src/components/modal/team/UpdateModalTeam.tsx
@@ -118,7 +118,7 @@ export default function UpdateModalTeam({ teamId, onClose: handleClose }: Update
           </form>
         </FormProvider>
 
-        <ModalButton formId={updateTeamFormId} backgroundColor="bg-main">
+        <ModalButton formId={updateTeamFormId} color="text-white" backgroundColor="bg-main">
           수정
         </ModalButton>
 

--- a/src/components/task/calendar/CustomEventWrapper.tsx
+++ b/src/components/task/calendar/CustomEventWrapper.tsx
@@ -28,7 +28,7 @@ export default function CustomEventWrapper(props: EventWrapperProps<CustomEvent>
   return (
     <div
       style={{ backgroundColor: event.task.colorCode }}
-      className={`overflow-hidden text-ellipsis rounded-md px-3 py-1 ${continuesClass}`}
+      className={`overflow-hidden text-ellipsis rounded-md px-3 py-1 ${continuesClass} hover:brightness-90`}
     >
       {children}
     </div>

--- a/src/components/task/kanban/TaskItem.tsx
+++ b/src/components/task/kanban/TaskItem.tsx
@@ -14,12 +14,13 @@ type TaskItemProps = {
   colorCode: ProjectStatus['colorCode'];
 };
 
+// ToDo: React Reparenting 관련된 문제가 있음.
 export default function TaskItem({ task, colorCode }: TaskItemProps) {
   const { project } = useProjectContext();
   const { showModal: showDetailModal, openModal: openDetailModal, closeModal: closeDetailModal } = useModal();
   const { showModal: showUpdateModal, openModal: openUpdateModal, closeModal: closeUpdateModal } = useModal();
 
-  const { taskId, taskName, sortOrder } = task;
+  const { taskId, statusId, taskName, sortOrder } = task;
   const index = useMemo(() => sortOrder - 1, [sortOrder]);
   const draggableId = useMemo(() => generatePrefixId(taskId, DND_DRAGGABLE_PREFIX.TASK), [taskId]);
 
@@ -47,8 +48,8 @@ export default function TaskItem({ task, colorCode }: TaskItemProps) {
       {showDetailModal && (
         <DetailModalTask
           projectId={project.projectId}
-          statusId={task.statusId}
-          taskId={task.taskId}
+          statusId={statusId}
+          taskId={taskId}
           openUpdateModal={openUpdateModal}
           onClose={closeDetailModal}
         />
@@ -56,7 +57,7 @@ export default function TaskItem({ task, colorCode }: TaskItemProps) {
       {showUpdateModal && (
         <UpdateModalTask
           project={project}
-          taskId={task.taskId}
+          taskId={taskId}
           openDetailModal={openDetailModal}
           onClose={closeUpdateModal}
         />

--- a/src/components/task/kanban/TaskItem.tsx
+++ b/src/components/task/kanban/TaskItem.tsx
@@ -45,9 +45,22 @@ export default function TaskItem({ task, colorCode }: TaskItemProps) {
         )}
       </Draggable>
       {showDetailModal && (
-        <DetailModalTask project={project} task={task} openUpdateModal={openUpdateModal} onClose={closeDetailModal} />
+        <DetailModalTask
+          projectId={project.projectId}
+          statusId={task.statusId}
+          taskId={task.taskId}
+          openUpdateModal={openUpdateModal}
+          onClose={closeDetailModal}
+        />
       )}
-      {showUpdateModal && <UpdateModalTask project={project} taskId={task.taskId} onClose={closeUpdateModal} />}
+      {showUpdateModal && (
+        <UpdateModalTask
+          project={project}
+          taskId={task.taskId}
+          openDetailModal={openDetailModal}
+          onClose={closeUpdateModal}
+        />
+      )}
     </>
   );
 }

--- a/src/hooks/query/useTaskQuery.ts
+++ b/src/hooks/query/useTaskQuery.ts
@@ -182,7 +182,7 @@ export function useUpdateTaskInfo(projectId: Project['projectId'], taskId: Task[
     onError: () => toastError('일정 정보 수정에 실패했습니다. 잠시 후 다시 시도해 주세요.'),
     onSuccess: () => {
       toastSuccess('일정 정보를 수정했습니다.');
-      queryClient.invalidateQueries({ queryKey: tasksQueryKey });
+      queryClient.invalidateQueries({ queryKey: tasksQueryKey, exact: true });
     },
   });
 

--- a/src/pages/project/CalendarPage.tsx
+++ b/src/pages/project/CalendarPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { DateTime, Settings } from 'luxon';
 import { Calendar, luxonLocalizer, Views } from 'react-big-calendar';
 import DetailModalTask from '@components/modal/task/DetailModalTask';
@@ -33,24 +33,26 @@ function getCalendarTask(statusTasks: TaskListWithStatus[]) {
 const dt = DateTime.local();
 Settings.defaultZone = dt.zoneName;
 const localizer = luxonLocalizer(DateTime, { firstDayOfWeek: 7 });
+const initialTask = { taskId: 0, statusId: 0, taskName: '', content: '', startDate: '', endDate: '', sortOrder: 0 };
 
 // ToDo: Loading시 infinite spinner UI 보이도록 변경할 것
 // ToDo: Error 발생시 처리 추가할 것
 export default function CalendarPage() {
-  const [selectedTask, setSelectedTask] = useState<Task>({
-    taskId: 0,
-    statusId: 0,
-    taskName: '',
-    content: '',
-    startDate: '',
-    endDate: '',
-    sortOrder: 0,
-  });
+  const [selectedTask, setSelectedTask] = useState<Task>(initialTask);
   const [date, setDate] = useState<Date>(() => DateTime.now().toJSDate());
   const { project } = useProjectContext();
   const { statusTaskList, isTaskLoading, isTaskError, taskError } = useReadStatusTasks(project.projectId);
   const { showModal: showDetailModal, openModal: openDetailModal, closeModal: closeDetailModal } = useModal();
   const { showModal: showUpdateModal, openModal: openUpdateModal, closeModal: closeUpdateModal } = useModal();
+
+  // 일정 정보 수정시 데이터 동기화를 위한 처리
+  useEffect(() => {
+    const statusTask = getCalendarTask(statusTaskList).find((task) => task.taskId === selectedTask.taskId);
+    if (statusTask) {
+      const { taskId, statusId, taskName, content, startDate, endDate, sortOrder } = statusTask;
+      setSelectedTask({ taskId, statusId, taskName, content, startDate, endDate, sortOrder });
+    }
+  }, [statusTaskList]);
 
   const handleNavigate = useCallback((newDate: Date) => setDate(newDate), [setDate]);
 
@@ -90,20 +92,21 @@ export default function CalendarPage() {
     [],
   );
 
-  const events: CustomEvent[] = getCalendarTask(statusTaskList)
-    .map((task) => ({
-      title: task.taskName,
-      start: new Date(task.startDate),
-      end: new Date(task.endDate),
-      allDay: true,
-      task: { ...task },
-    }))
-    .sort((a, b) => a.start.getTime() - b.start.getTime());
+  const events: CustomEvent[] = useMemo(() => {
+    console.log('이벤트 정리');
+    return getCalendarTask(statusTaskList)
+      .map((task) => ({
+        title: task.taskName,
+        start: new Date(task.startDate),
+        end: new Date(task.endDate),
+        allDay: true,
+        task: { ...task },
+      }))
+      .sort((a, b) => a.start.getTime() - b.start.getTime());
+  }, [statusTaskList]);
   const startDate = events.length && events[0].start ? events[0].start : null;
 
   // ToDo: DnD, Resize 이벤트 추가 생각해보기
-  // ToDo: 할일 추가 모달 Form 작업 완료시 모달 컴포넌트 분리
-  // ToDo: 캘린더 크기 전체적으로 조정
   // ToDo: 코드 리팩토링
   return (
     <div className="flex h-full min-h-375 w-full min-w-260 flex-col">
@@ -132,13 +135,21 @@ export default function CalendarPage() {
       />
       {showDetailModal && (
         <DetailModalTask
-          project={project}
-          task={selectedTask}
+          projectId={project.projectId}
+          statusId={selectedTask.statusId}
+          taskId={selectedTask.taskId}
           openUpdateModal={openUpdateModal}
           onClose={closeDetailModal}
         />
       )}
-      {showUpdateModal && <UpdateModalTask project={project} taskId={selectedTask.taskId} onClose={closeUpdateModal} />}
+      {showUpdateModal && (
+        <UpdateModalTask
+          project={project}
+          taskId={selectedTask.taskId}
+          openDetailModal={openDetailModal}
+          onClose={closeUpdateModal}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/project/CalendarPage.tsx
+++ b/src/pages/project/CalendarPage.tsx
@@ -52,7 +52,7 @@ export default function CalendarPage() {
       const { taskId, statusId, taskName, content, startDate, endDate, sortOrder } = statusTask;
       setSelectedTask({ taskId, statusId, taskName, content, startDate, endDate, sortOrder });
     }
-  }, [statusTaskList]);
+  }, [statusTaskList, selectedTask.taskId]);
 
   const handleNavigate = useCallback((newDate: Date) => setDate(newDate), [setDate]);
 

--- a/src/pages/project/CalendarPage.tsx
+++ b/src/pages/project/CalendarPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { DateTime, Settings } from 'luxon';
 import { Calendar, luxonLocalizer, Views } from 'react-big-calendar';
+import Spinner from '@components/common/Spinner';
 import DetailModalTask from '@components/modal/task/DetailModalTask';
 import UpdateModalTask from '@components/modal/task/UpdateModalTask';
 import CalendarToolbar from '@components/task/calendar/CalendarToolbar';
@@ -35,7 +36,6 @@ Settings.defaultZone = dt.zoneName;
 const localizer = luxonLocalizer(DateTime, { firstDayOfWeek: 7 });
 const initialTask = { taskId: 0, statusId: 0, taskName: '', content: '', startDate: '', endDate: '', sortOrder: 0 };
 
-// ToDo: Loading시 infinite spinner UI 보이도록 변경할 것
 // ToDo: Error 발생시 처리 추가할 것
 export default function CalendarPage() {
   const [selectedTask, setSelectedTask] = useState<Task>(initialTask);
@@ -93,7 +93,6 @@ export default function CalendarPage() {
   );
 
   const events: CustomEvent[] = useMemo(() => {
-    console.log('이벤트 정리');
     return getCalendarTask(statusTaskList)
       .map((task) => ({
         title: task.taskName,
@@ -110,45 +109,51 @@ export default function CalendarPage() {
   // ToDo: 코드 리팩토링
   return (
     <div className="flex h-full min-h-375 w-full min-w-260 flex-col">
-      <CalendarToolbar date={date} startDate={startDate} onClick={handleNavigate} />
-      <Calendar
-        toolbar={false}
-        localizer={localizer}
-        defaultView="month"
-        date={date}
-        onNavigate={handleNavigate}
-        drilldownView={null}
-        views={views}
-        events={events}
-        components={customComponents}
-        titleAccessor="title"
-        startAccessor="start"
-        endAccessor="end"
-        allDayAccessor="allDay"
-        popup
-        showAllEvents={false}
-        dayPropGetter={handleDayPropGetter}
-        eventPropGetter={handleEventPropGetter}
-        selectable
-        onSelectSlot={handleSelectSlot}
-        onSelectEvent={handleSelectEvent}
-      />
-      {showDetailModal && (
-        <DetailModalTask
-          projectId={project.projectId}
-          statusId={selectedTask.statusId}
-          taskId={selectedTask.taskId}
-          openUpdateModal={openUpdateModal}
-          onClose={closeDetailModal}
-        />
-      )}
-      {showUpdateModal && (
-        <UpdateModalTask
-          project={project}
-          taskId={selectedTask.taskId}
-          openDetailModal={openDetailModal}
-          onClose={closeUpdateModal}
-        />
+      {isTaskLoading ? (
+        <Spinner />
+      ) : (
+        <>
+          <CalendarToolbar date={date} startDate={startDate} onClick={handleNavigate} />
+          <Calendar
+            toolbar={false}
+            localizer={localizer}
+            defaultView="month"
+            date={date}
+            onNavigate={handleNavigate}
+            drilldownView={null}
+            views={views}
+            events={events}
+            components={customComponents}
+            titleAccessor="title"
+            startAccessor="start"
+            endAccessor="end"
+            allDayAccessor="allDay"
+            popup
+            showAllEvents={false}
+            dayPropGetter={handleDayPropGetter}
+            eventPropGetter={handleEventPropGetter}
+            selectable
+            onSelectSlot={handleSelectSlot}
+            onSelectEvent={handleSelectEvent}
+          />
+          {showDetailModal && (
+            <DetailModalTask
+              projectId={project.projectId}
+              statusId={selectedTask.statusId}
+              taskId={selectedTask.taskId}
+              openUpdateModal={openUpdateModal}
+              onClose={closeDetailModal}
+            />
+          )}
+          {showUpdateModal && (
+            <UpdateModalTask
+              project={project}
+              taskId={selectedTask.taskId}
+              openDetailModal={openDetailModal}
+              onClose={closeUpdateModal}
+            />
+          )}
+        </>
       )}
     </div>
   );

--- a/src/pages/project/KanbanPage.tsx
+++ b/src/pages/project/KanbanPage.tsx
@@ -61,9 +61,7 @@ export default function KanbanPage() {
   const [localStatusTaskList, setLocalStatusTaskList] = useState(statusTaskList);
 
   useEffect(() => {
-    if (statusTaskList) {
-      setLocalStatusTaskList(statusTaskList);
-    }
+    if (statusTaskList) setLocalStatusTaskList(statusTaskList);
   }, [statusTaskList]);
 
   const handleDragEnd = (dropResult: DropResult) => {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] **\[Feat\]** 새로운 기능을 추가했어요.
- [x] **\[Refactor\]** 리팩토링을 했어요 (기능적인 변화 없이, api 변경 없이)
- [x] **\[Comment\]** 필요한 주석 추가/삭제/변경 했어요.

## Related Issues
- close #204 

## What does this PR do?
- [x] 일정 수정 버튼 클릭 시 모달이 닫히는 기능 제거
- [x] ModalButton text 색상 props 추가
- [x] 일정 상세보기 모달에서 일정 정보를 찾도록 수정
- [x] 캘린더 양식에서 일정을 hover시 CSS 처리 추가
- [x] QueryFilter 옵션 수정으로 refetch 요청 최소화
- [x] 일정 목록 로딩시 캘린더에서 Spinner UI가 나오도록 수정
- [x] 돌아가기 버튼 추가

## Other information
캘린더 양식에서는 문제없이 수정이 가능하지만, 칸반 보드에서 문제가 되는 부분이 있습니다.

일정 수정 모달에서는 다음과 같이 크게 3가지 영역으로 나뉘어 개별적으로 일정 정보를 수정하고 있습니다.
```
1. 일정 상태, 일정명, 기간(시작일/종료일), 일정 내용 수정 ⇒　일정 정보 수정 API
2. 수행자 추가/삭제 ⇒ 일정 수행자 추가 API, 일정 수행자 삭제 API
3. 파일 추가/삭제 ⇒ 일정 파일 추가 API, 일정 파일 삭제 API
```

이중에서 1번의 경우에서 특히 일정 상태를 수정할 때 발생하는 문제입니다. (일정명, 기간, 일정 내용 수정은 괜찮습니다.) 일정명, 기간, 일정 내용은 수정이 되더라도 TaskItem이라는 컴포넌트가 리렌더링이될 뿐 빠르게 언마운트 후 마운트하지 않습니다. 하지만 일정 상태를 수정하는 경우, 상태를 수정한 TaskItem에 한해서면 언마운트 후 마운트를 수행합니다. 때문에 일정 수정 모달의 showModal 정보가 초기화 되면서 모달 컴포넌트가 자동으로 사라집니다.

![화면 예시 - 일정 상세보기 돌아가기 버튼 칸반보드 문제](https://github.com/user-attachments/assets/4bf71244-24f7-4631-bc16-3b8f59ba96a3)

처음에는 react 상태(props, state), key 등의 영향으로 발생하는건가 고민해보았지만, 뚜렷히 원인을 찾을 수 없었고, react-beautiful-dnd 라이브러리의 issue를 확인하여 [비슷한 상황](https://github.com/atlassian/react-beautiful-dnd/issues/1650)을 겪은 내용을 찾았습니다.  해당 이슈도 dragend 이후 item이 unmount-remount가 일어난다는 것이었고, 이를 통해 [react에도 등록되어 있는 이슈](https://github.com/facebook/react/issues/3965)임을 알게 되었습니다.

내용을 읽어보던중 [react reparenting](https://github.com/Paol-imi/react-reparenting)이라는 개념을 처음 접하게 되었습니다. react reparenting이란 부모에 속한 자식 노드가 다른 부모에게 옮겨갈 때 구성된 트리 구조가 변경되게 되어 언마운트와 리마운트가 일어난다는 개념이었습니다. 일단은 지금까지 만든 내용을 넣고 다른 PR에서 해결하려고 생각하고 있습니다.

![reparenting](https://github.com/user-attachments/assets/491ee820-98b5-4967-bf5e-94e968bef978)

[Reparenting is now possible with React](https://dev.to/paolimi/reparenting-is-now-possible-with-react-3ci0)를 참고하여 해결책을 찾아보려고 합니다.

## View
![화면 예시 - 일정 상세보기 돌아가기 버튼](https://github.com/user-attachments/assets/910ef62a-630d-47ee-aa0f-4a94d7354398)

