### PR TITLE
Feat: #208 PeriodDateInput 컴포넌트 종료일 토글 자동 활성화 기능 추가

### DIFF
--- a/src/components/common/PeriodDateInput.tsx
+++ b/src/components/common/PeriodDateInput.tsx
@@ -43,8 +43,8 @@ export default function PeriodDateInput({
   const endDateStr = watch(endDateFieldName);
 
   useEffect(() => {
-    const startDate = startDateStr ? DateTime.fromJSDate(new Date(startDateStr)).startOf('day') : null;
-    const endDate = endDateStr ? DateTime.fromJSDate(new Date(endDateStr)).startOf('day') : null;
+    const startDate = startDateStr ? DateTime.fromISO(startDateStr).startOf('day') : null;
+    const endDate = endDateStr ? DateTime.fromISO(endDateStr).startOf('day') : null;
     if (startDate && endDate) setHasDeadline(startDate < endDate);
   }, [startDateStr, endDateStr]);
 
@@ -84,8 +84,8 @@ export default function PeriodDateInput({
           {...register(endDateFieldName, {
             ...TASK_VALIDATION_RULES.END_DATE(hasDeadline, limitStartDate, limitEndDate, watch(startDateFieldName)),
             onChange: (e) => {
-              const startDate = DateTime.fromJSDate(new Date(startDateStr)).startOf('day');
-              const endDate = DateTime.fromJSDate(new Date(e.target.value)).startOf('day');
+              const startDate = DateTime.fromISO(startDateStr).startOf('day');
+              const endDate = DateTime.fromISO(e.target.value).startOf('day');
               if (startDate > endDate) {
                 toastWarn('종료일은 시작일과 같거나 이후로 설정해주세요.');
                 setValue(endDateFieldName, startDateStr);

--- a/src/components/common/PeriodDateInput.tsx
+++ b/src/components/common/PeriodDateInput.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useState } from 'react';
+import { DateTime } from 'luxon';
 import { useFormContext } from 'react-hook-form';
 import { TASK_VALIDATION_RULES } from '@constants/formValidationRules';
 import ToggleButton from '@components/common/ToggleButton';
+import useToast from '@hooks/useToast';
 
 import type { FieldError } from 'react-hook-form';
-import { DateTime } from 'luxon';
 import type { Project } from '@/types/ProjectType';
-import { DAY } from '@/constants/units';
-import useToast from '@/hooks/useToast';
 
 type PeriodDateInputProps = {
   startDateId: string;

--- a/src/components/common/PeriodDateInput.tsx
+++ b/src/components/common/PeriodDateInput.tsx
@@ -1,33 +1,37 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { TASK_VALIDATION_RULES } from '@constants/formValidationRules';
 import ToggleButton from '@components/common/ToggleButton';
 
 import type { FieldError } from 'react-hook-form';
+import { DateTime } from 'luxon';
 import type { Project } from '@/types/ProjectType';
+import { DAY } from '@/constants/units';
+import useToast from '@/hooks/useToast';
 
 type PeriodDateInputProps = {
-  startDateLabel: string;
-  endDateLabel: string;
   startDateId: string;
   endDateId: string;
-  startDate: Project['startDate'];
-  endDate: Project['endDate'];
+  startDateLabel: string;
+  endDateLabel: string;
   startDateFieldName: string;
   endDateFieldName: string;
+  limitStartDate: Project['startDate'];
+  limitEndDate: Project['endDate'];
 };
 
 export default function PeriodDateInput({
-  startDateLabel,
-  endDateLabel,
   startDateId,
   endDateId,
-  startDate,
-  endDate,
+  startDateLabel,
+  endDateLabel,
   startDateFieldName,
   endDateFieldName,
+  limitStartDate,
+  limitEndDate,
 }: PeriodDateInputProps) {
   const [hasDeadline, setHasDeadline] = useState(false);
+  const { toastWarn } = useToast();
   const {
     setValue,
     getValues,
@@ -36,6 +40,14 @@ export default function PeriodDateInput({
     register,
     formState: { errors },
   } = useFormContext();
+  const startDateStr = watch(startDateFieldName);
+  const endDateStr = watch(endDateFieldName);
+
+  useEffect(() => {
+    const startDate = startDateStr ? DateTime.fromJSDate(new Date(startDateStr)).startOf('day') : null;
+    const endDate = endDateStr ? DateTime.fromJSDate(new Date(endDateStr)).startOf('day') : null;
+    if (startDate && endDate) setHasDeadline(startDate < endDate);
+  }, [startDateStr, endDateStr]);
 
   const handleDeadlineToggle = () => {
     setValue(endDateFieldName, getValues(startDateFieldName));
@@ -51,7 +63,7 @@ export default function PeriodDateInput({
           id={startDateId}
           type="date"
           {...register(startDateFieldName, {
-            ...TASK_VALIDATION_RULES.START_DATE(startDate, endDate),
+            ...TASK_VALIDATION_RULES.START_DATE(limitStartDate, limitEndDate),
             onChange: (e) => {
               if (!hasDeadline) setValue(endDateFieldName, e.target.value);
             },
@@ -70,11 +82,18 @@ export default function PeriodDateInput({
           id={endDateId}
           type="date"
           className={`${hasDeadline ? '' : '!bg-disable'}`}
-          disabled={!hasDeadline}
-          {...register(
-            endDateFieldName,
-            TASK_VALIDATION_RULES.END_DATE(hasDeadline, startDate, endDate, watch(startDateFieldName)),
-          )}
+          {...register(endDateFieldName, {
+            ...TASK_VALIDATION_RULES.END_DATE(hasDeadline, limitStartDate, limitEndDate, watch(startDateFieldName)),
+            onChange: (e) => {
+              const startDate = DateTime.fromJSDate(new Date(startDateStr)).startOf('day');
+              const endDate = DateTime.fromJSDate(new Date(e.target.value)).startOf('day');
+              if (startDate > endDate) {
+                toastWarn('종료일은 시작일과 같거나 이후로 설정해주세요.');
+                setValue(endDateFieldName, startDateStr);
+                setHasDeadline(false);
+              }
+            },
+          })}
         />
         <div className={`my-5 h-10 grow text-xs text-error ${errors[endDateFieldName] ? 'visible' : 'invisible'}`}>
           {(errors[endDateFieldName] as FieldError | undefined)?.message}

--- a/src/components/modal/task/ModalTaskForm.tsx
+++ b/src/components/modal/task/ModalTaskForm.tsx
@@ -37,7 +37,7 @@ type ModalTaskFormProps = {
 
 // ToDo: React Query Error시 처리 추가할 것
 export default function ModalTaskForm({ formId, project, taskId, onSubmit }: ModalTaskFormProps) {
-  const { projectId, startDate: projctStartDate, endDate: projectEndDate } = project;
+  const { projectId, startDate: projectStartDate, endDate: projectEndDate } = project;
 
   const [keyword, setKeyword] = useState('');
   const [assignees, setAssignees] = useState<UserWithRole[]>([]);
@@ -159,7 +159,7 @@ export default function ModalTaskForm({ formId, project, taskId, onSubmit }: Mod
           endDateLabel="종료일"
           startDateFieldName="startDate"
           endDateFieldName="endDate"
-          limitStartDate={projctStartDate}
+          limitStartDate={projectStartDate}
           limitEndDate={projectEndDate}
         />
 

--- a/src/components/modal/task/ModalTaskForm.tsx
+++ b/src/components/modal/task/ModalTaskForm.tsx
@@ -37,7 +37,7 @@ type ModalTaskFormProps = {
 
 // ToDo: React Query Error시 처리 추가할 것
 export default function ModalTaskForm({ formId, project, taskId, onSubmit }: ModalTaskFormProps) {
-  const { projectId, startDate, endDate } = project;
+  const { projectId, startDate: projctStartDate, endDate: projectEndDate } = project;
 
   const [keyword, setKeyword] = useState('');
   const [assignees, setAssignees] = useState<UserWithRole[]>([]);
@@ -153,14 +153,14 @@ export default function ModalTaskForm({ formId, project, taskId, onSubmit }: Mod
         />
 
         <PeriodDateInput
-          startDateLabel="시작일"
-          endDateLabel="종료일"
           startDateId="startDate"
           endDateId="endDate"
-          startDate={startDate}
-          endDate={endDate}
+          startDateLabel="시작일"
+          endDateLabel="종료일"
           startDateFieldName="startDate"
           endDateFieldName="endDate"
+          limitStartDate={projctStartDate}
+          limitEndDate={projectEndDate}
         />
 
         <div className="mb-20">

--- a/src/components/modal/task/UpdateModalTask.tsx
+++ b/src/components/modal/task/UpdateModalTask.tsx
@@ -43,7 +43,7 @@ type UpdateModalTaskProps = {
 
 export default function UpdateModalTask({ project, taskId, onClose: handleClose }: UpdateModalTaskProps) {
   const updateTaskFormId = 'updateTaskForm';
-  const { projectId, startDate, endDate } = project;
+  const { projectId, startDate: projectStartDate, endDate: projectEndDate } = project;
 
   const [keyword, setKeyword] = useState('');
   const { toastInfo, toastWarn } = useToast();
@@ -155,14 +155,14 @@ export default function UpdateModalTask({ project, taskId, onClose: handleClose 
                 />
 
                 <PeriodDateInput
-                  startDateLabel="시작일"
-                  endDateLabel="종료일"
                   startDateId="startDate"
                   endDateId="endDate"
-                  startDate={startDate}
-                  endDate={endDate}
+                  startDateLabel="시작일"
+                  endDateLabel="종료일"
                   startDateFieldName="startDate"
                   endDateFieldName="endDate"
+                  limitStartDate={projectStartDate}
+                  limitEndDate={projectEndDate}
                 />
 
                 <MarkdownEditor id="content" label="내용" contentFieldName="content" />

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -33,7 +33,17 @@ export async function findUserByProject(
  * @returns {Promise<AxiosResponse<Project[]>>}
  */
 export async function getProjectList(teamId: Team['teamId'], axiosConfig: AxiosRequestConfig = {}) {
-  return authAxios.get<Project[]>(`/team/${teamId}/project`, axiosConfig);
+  return authAxios.get<Project[]>(`/team/${teamId}/project`, {
+    transformResponse: (data) => {
+      const parsedData: Project[] = JSON.parse(data);
+      return parsedData.map((data) => {
+        data.startDate = data.startDate && new Date(data.startDate);
+        data.endDate = data.endDate && new Date(data.endDate);
+        return data;
+      });
+    },
+    ...axiosConfig,
+  });
 }
 
 /**

--- a/src/utils/Validator.ts
+++ b/src/utils/Validator.ts
@@ -16,15 +16,16 @@ export default class Validator {
   }
 
   public static isWithinDateRange(start: Date | string, end: Date | string, target: Date | string) {
-    const startDate = DateTime.fromJSDate(new Date(start));
-    const endDate = DateTime.fromJSDate(new Date(end));
-    const targetDate = DateTime.fromJSDate(new Date(target));
+    const startDate = DateTime.fromJSDate(new Date(start)).startOf('day');
+    const endDate = DateTime.fromJSDate(new Date(end)).startOf('day');
+    const targetDate = DateTime.fromJSDate(new Date(target)).startOf('day');
     return targetDate >= startDate && targetDate < endDate;
   }
 
   public static isEarlierStartDate(start: Date | string, end: Date | string) {
-    const startDate = DateTime.fromJSDate(new Date(start));
-    const endDate = DateTime.fromJSDate(new Date(end));
+    const startDate = DateTime.fromJSDate(new Date(start)).startOf('day');
+    const endDate = DateTime.fromJSDate(new Date(end)).startOf('day');
+    console.log(startDate.toISODate(), endDate.toISODate());
     return startDate <= endDate;
   }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] **\[Feat\]** 새로운 기능을 추가했어요.

## Related Issues
- close #208 

## What does this PR do?
- [x] 날짜 관련 Validation 로직 수정
- [x] 프로젝트 목록 조회 API 데이터 타입 변환 함수 추가
- [x] PeriodDateInput 컴포넌트 종료일 토글 자동 활성화/비활성화 기능 추가
- [x] 종료일이 시작일보다 빠른 경우 경고 메시지와 함께 시작일로 변경 기능 추가

## Other information
현재 ERD 설계상으로는 DateTime으로 되어있지만, 실질적인 데이터는 연월일로 설정되기 때문에 Validation 로직을 일부 수정하였습니다. 또한 프로젝트 타입(Project)의 startDate와 endDate가 Date 타입으로 설정되어 있지만, 프로젝트 목록 조회시 네트워크로 받은 JSON 데이터를 파싱하여 변환하지 않아 여전히 문자열로 받는 문제가 있었습니다. 이를 해결하기 위해 프로젝트 목록 조회 API에 transformResponse 옵션을 추가하여 데이터 타입을 일치시키도록 수정했습니다.

## View
**기간 설정에 따른 종료일 토글 자동 활성화/비활성화**
![화면 예시 - periodDateInput 자동 활성화](https://github.com/user-attachments/assets/44acbfa0-bf69-43b8-9602-be3f24247091)

**기간 설정 중 종료일이 시작일보다 빠른 날짜를 설정하는 경우: 종료일 토글 비활성화 & 시작일과 일치**
![화면 예시 - periodDateInput 종료일이 시작일보다 빠른 경우](https://github.com/user-attachments/assets/c2a70a51-236f-41c2-a1ee-398d9e7c92b6)

**기간 설정중 종료일이 시작일과 같아지는 경우: 종료일 토글 비활성화**
![화면 예시 - periodDateInput 종료일이 시작일과 같은 경우 토글 비활성화](https://github.com/user-attachments/assets/8bc6db22-8686-436b-94ec-4da1c088631d)

**기간 설정중 종료일 설정 토글을 비활성화하는 경우: 종료일을 시작일과 일치**
![화면 예시 - periodDateInput 종료일 토글 비활성화시 시작일과 같아짐](https://github.com/user-attachments/assets/c70e5020-bd6b-4db3-86d3-db09826ea26a)

**종료일 설정 토글이 비활성화 되어 있을 때 시작일을 이동하는 경우: 종료일을 항상 시작일과 일치**
![화면 예시 - periodDateInput 종료일이 비활성화시 시작일 변경과 함께 이동](https://github.com/user-attachments/assets/2c8376ae-82b1-41c6-947f-2ac9ffe24403)