### PR TITLE
Feat: #211 유저 프로필 이미지 업로드 기능 구현

### DIFF
--- a/src/components/user/auth-form/ProfileImageContainer.tsx
+++ b/src/components/user/auth-form/ProfileImageContainer.tsx
@@ -1,19 +1,22 @@
+import { useEffect } from 'react';
 import { GoPlusCircle } from 'react-icons/go';
 import { FaRegTrashCan } from 'react-icons/fa6';
 import { useFormContext } from 'react-hook-form';
 import { convertBytesToString } from '@utils/converter';
 import { USER_SETTINGS } from '@constants/settings';
 import useToast from '@hooks/useToast';
-import { useEffect } from 'react';
+import { useUploadProfileImage } from '@hooks/query/useUserQuery';
+import useStore from '@stores/useStore';
 
 type ProfileImageContainerProps = {
   imageUrl: string | null;
-  setImageUrl: (url: string) => void;
 };
 
-export default function ProfileImageContainer({ imageUrl, setImageUrl }: ProfileImageContainerProps) {
+export default function ProfileImageContainer({ imageUrl }: ProfileImageContainerProps) {
   const { setValue } = useFormContext();
   const { toastWarn } = useToast();
+  const { mutate: uploadImage } = useUploadProfileImage();
+  const { editUserInfo } = useStore();
 
   useEffect(() => {
     return () => {
@@ -32,14 +35,17 @@ export default function ProfileImageContainer({ imageUrl, setImageUrl }: Profile
       );
     }
 
-    const image = URL.createObjectURL(file);
-    setImageUrl(image);
-    setValue('profileImageName', image);
+    uploadImage({ file });
+
+    const localImageUrl = URL.createObjectURL(file);
+    const uniqueFileName = `PROFILE_IMAGE_${Date.now()}.jpg`;
+    setValue('profileImageName', localImageUrl);
+    editUserInfo({ profileImageName: uniqueFileName });
   };
 
   const handleRemoveImg = () => {
-    setImageUrl('');
-    setValue('profileImageName', '');
+    setValue('profileImageName', null);
+    editUserInfo({ profileImageName: null });
   };
 
   return (

--- a/src/components/user/auth-form/ProfileImageContainer.tsx
+++ b/src/components/user/auth-form/ProfileImageContainer.tsx
@@ -16,7 +16,7 @@ type ProfileImageContainerProps = {
 export default function ProfileImageContainer({ imageUrl, setImageUrl }: ProfileImageContainerProps) {
   const { toastWarn } = useToast();
   const { mutate: uploadImageMutate } = useUploadProfileImage();
-  const { editUserInfo } = useStore();
+  const { editUserInfo, userInfo } = useStore();
 
   useEffect(() => {
     return () => {
@@ -46,8 +46,6 @@ export default function ProfileImageContainer({ imageUrl, setImageUrl }: Profile
 
     const localImageUrl = URL.createObjectURL(file);
     setImageUrl(localImageUrl);
-    // TODO: ZUSTAND 유저 프로필 이미지 업데이트 추후에 추가
-    // editUserInfo({ profileImageName: uniqueFileName });
   };
 
   const handleRemoveImg = () => {

--- a/src/components/user/auth-form/ProfileImageContainer.tsx
+++ b/src/components/user/auth-form/ProfileImageContainer.tsx
@@ -1,19 +1,19 @@
 import { useEffect } from 'react';
 import { GoPlusCircle } from 'react-icons/go';
 import { FaRegTrashCan } from 'react-icons/fa6';
-import { useFormContext } from 'react-hook-form';
 import { convertBytesToString } from '@utils/converter';
 import { USER_SETTINGS } from '@constants/settings';
+import { JPG, PNG, SVG, WEBP } from '@constants/mimeFileType';
 import useToast from '@hooks/useToast';
 import { useUploadProfileImage } from '@hooks/query/useUserQuery';
 import useStore from '@stores/useStore';
 
 type ProfileImageContainerProps = {
   imageUrl: string | null;
+  setImageUrl: (url: string) => void;
 };
 
-export default function ProfileImageContainer({ imageUrl }: ProfileImageContainerProps) {
-  const { setValue } = useFormContext();
+export default function ProfileImageContainer({ imageUrl, setImageUrl }: ProfileImageContainerProps) {
   const { toastWarn } = useToast();
   const { mutate: uploadImage } = useUploadProfileImage();
   const { editUserInfo } = useStore();
@@ -35,16 +35,23 @@ export default function ProfileImageContainer({ imageUrl }: ProfileImageContaine
       );
     }
 
+    const IMG_TYPE = [JPG, PNG, WEBP, SVG];
+    const permitType = IMG_TYPE.some((type) => type === file.type);
+    if (!permitType) {
+      e.target.value = '';
+      return toastWarn(`${IMG_TYPE.join(', ')} 형식의 이미지 파일만 업로드 가능합니다.`);
+    }
+
     uploadImage({ file });
 
     const localImageUrl = URL.createObjectURL(file);
-    const uniqueFileName = `PROFILE_IMAGE_${Date.now()}.jpg`;
-    setValue('profileImageName', localImageUrl);
-    editUserInfo({ profileImageName: uniqueFileName });
+    setImageUrl(localImageUrl);
+    // TODO: ZUSTAND 유저 프로필 이미지 업데이트 추후에 추가
+    // editUserInfo({ profileImageName: uniqueFileName });
   };
 
   const handleRemoveImg = () => {
-    setValue('profileImageName', null);
+    setImageUrl('');
     editUserInfo({ profileImageName: null });
   };
 

--- a/src/components/user/auth-form/ProfileImageContainer.tsx
+++ b/src/components/user/auth-form/ProfileImageContainer.tsx
@@ -15,7 +15,7 @@ type ProfileImageContainerProps = {
 
 export default function ProfileImageContainer({ imageUrl, setImageUrl }: ProfileImageContainerProps) {
   const { toastWarn } = useToast();
-  const { mutate: uploadImage } = useUploadProfileImage();
+  const { mutate: uploadImageMutate } = useUploadProfileImage();
   const { editUserInfo } = useStore();
 
   useEffect(() => {
@@ -42,7 +42,7 @@ export default function ProfileImageContainer({ imageUrl, setImageUrl }: Profile
       return toastWarn(`${IMG_EXTENSIONS.join(', ')} 형식의 이미지 파일만 업로드 가능합니다.`);
     }
 
-    uploadImage({ file });
+    uploadImageMutate({ file });
 
     const localImageUrl = URL.createObjectURL(file);
     setImageUrl(localImageUrl);

--- a/src/components/user/auth-form/ProfileImageContainer.tsx
+++ b/src/components/user/auth-form/ProfileImageContainer.tsx
@@ -35,11 +35,11 @@ export default function ProfileImageContainer({ imageUrl, setImageUrl }: Profile
       );
     }
 
-    const IMG_TYPE = [JPG, PNG, WEBP, SVG];
-    const permitType = IMG_TYPE.some((type) => type === file.type);
+    const IMG_EXTENSIONS = [JPG, PNG, WEBP, SVG];
+    const permitType = IMG_EXTENSIONS.some((extensions) => extensions === file.type);
     if (!permitType) {
       e.target.value = '';
-      return toastWarn(`${IMG_TYPE.join(', ')} 형식의 이미지 파일만 업로드 가능합니다.`);
+      return toastWarn(`${IMG_EXTENSIONS.join(', ')} 형식의 이미지 파일만 업로드 가능합니다.`);
     }
 
     uploadImage({ file });

--- a/src/hooks/query/useUserQuery.ts
+++ b/src/hooks/query/useUserQuery.ts
@@ -25,7 +25,7 @@ export function useUpdateUserInfo() {
 export function useUploadProfileImage() {
   const queryClient = useQueryClient();
   const { toastSuccess, toastError } = useToast();
-  const { userInfo } = useStore();
+  const { userInfo, editUserInfo } = useStore();
   const userProfileImageQueryKey = generateProfileFileQueryKey(userInfo.userId);
 
   const mutation = useMutation({
@@ -34,8 +34,13 @@ export function useUploadProfileImage() {
         headers: { 'Content-Type': 'multipart/form-data' },
       }),
     onError: () => toastError('이미지 업로드에 실패했습니다. 다시 시도해 주세요.'),
-    onSuccess: () => {
+    onSuccess: (response) => {
+      const { imageName } = response.data;
+
+      if (!imageName) return toastError('이미지 업로드에 실패했습니다. 다시 시도해 주세요.');
+
       toastSuccess('이미지가 업로드되었습니다.');
+      editUserInfo({ profileImageName: imageName });
       queryClient.invalidateQueries({ queryKey: userProfileImageQueryKey });
     },
   });

--- a/src/hooks/query/useUserQuery.ts
+++ b/src/hooks/query/useUserQuery.ts
@@ -1,7 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import useToast from '@hooks/useToast';
-import { updateUserInfo } from '@services/userService';
-import { generateUserInfoQueryKey } from '@/utils/queryKeyGenerator';
+import { updateUserInfo, uploadProfileImage } from '@services/userService';
+import useStore from '@stores/useStore';
+import { generateProfileFileQueryKey, generateUserInfoQueryKey } from '@utils/queryKeyGenerator';
 import type { EditUserInfoRequest } from '@/types/UserType';
 
 export function useUpdateUserInfo() {
@@ -15,6 +16,27 @@ export function useUpdateUserInfo() {
     onSuccess: () => {
       toastSuccess('유저 정보가 수정되었습니다.');
       queryClient.invalidateQueries({ queryKey: userInfoQueryKey });
+    },
+  });
+
+  return mutation;
+}
+
+export function useUploadProfileImage() {
+  const queryClient = useQueryClient();
+  const { toastSuccess, toastError } = useToast();
+  const { userInfo } = useStore();
+  const userProfileImageQueryKey = generateProfileFileQueryKey(userInfo.userId);
+
+  const mutation = useMutation({
+    mutationFn: ({ file }: { file: File }) =>
+      uploadProfileImage(file, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      }),
+    onError: () => toastError('이미지 업로드에 실패했습니다. 다시 시도해 주세요.'),
+    onSuccess: () => {
+      toastSuccess('이미지가 업로드되었습니다.');
+      queryClient.invalidateQueries({ queryKey: userProfileImageQueryKey });
     },
   });
 

--- a/src/mocks/mockData.ts
+++ b/src/mocks/mockData.ts
@@ -842,17 +842,17 @@ export const FILE_DUMMY: FileInfo[] = [
 export const PROFILE_IMAGE_DUMMY = [
   {
     userId: 1,
-    file: new Blob(['프로필_이미지_1'], { type: 'image/jpeg' }),
+    file: new Blob([], { type: 'image/jpeg' }),
     uploadName: 'PROFILE_IMAGE_UUID_1.jpg',
   },
   {
     userId: 2,
-    file: new Blob(['프로필_이미지_2'], { type: 'image/jpeg' }),
+    file: new Blob([], { type: 'image/jpeg' }),
     uploadName: 'PROFILE_IMAGE_UUID_2.jpg',
   },
   {
     userId: 3,
-    file: new Blob(['프로필_이미지_3'], { type: 'image/png' }),
+    file: new Blob([], { type: 'image/png' }),
     uploadName: 'PROFILE_IMAGE_UUID_3.jpg',
   },
 ];

--- a/src/mocks/mockData.ts
+++ b/src/mocks/mockData.ts
@@ -837,3 +837,22 @@ export const FILE_DUMMY: FileInfo[] = [
     uploadName: 'FILE_UUID_3.txt',
   },
 ];
+
+// MSW 프로필 이미지 임시 저장을 위한 변수
+export const PROFILE_IMAGE_DUMMY = [
+  {
+    userId: 1,
+    file: new Blob([''], { type: 'image/jpeg' }),
+    uploadName: 'PROFILE_IMAGE_UUID_1.jpg',
+  },
+  {
+    userId: 2,
+    file: new Blob([''], { type: 'image/jpeg' }),
+    uploadName: 'PROFILE_IMAGE_UUID_2.jpg',
+  },
+  {
+    userId: 3,
+    file: new Blob([''], { type: 'image/png' }),
+    uploadName: 'PROFILE_IMAGE_UUID_3.jpg',
+  },
+];

--- a/src/mocks/mockData.ts
+++ b/src/mocks/mockData.ts
@@ -842,17 +842,17 @@ export const FILE_DUMMY: FileInfo[] = [
 export const PROFILE_IMAGE_DUMMY = [
   {
     userId: 1,
-    file: new Blob([''], { type: 'image/jpeg' }),
+    file: new Blob(['프로필_이미지_1'], { type: 'image/jpeg' }),
     uploadName: 'PROFILE_IMAGE_UUID_1.jpg',
   },
   {
     userId: 2,
-    file: new Blob([''], { type: 'image/jpeg' }),
+    file: new Blob(['프로필_이미지_2'], { type: 'image/jpeg' }),
     uploadName: 'PROFILE_IMAGE_UUID_2.jpg',
   },
   {
     userId: 3,
-    file: new Blob([''], { type: 'image/png' }),
+    file: new Blob(['프로필_이미지_3'], { type: 'image/png' }),
     uploadName: 'PROFILE_IMAGE_UUID_3.jpg',
   },
 ];

--- a/src/mocks/mockData.ts
+++ b/src/mocks/mockData.ts
@@ -39,6 +39,12 @@ type FileInfo = {
   uploadName: string;
 };
 
+type ImageInfo = {
+  userId: number;
+  file: Blob;
+  uploadName: string;
+};
+
 export const JWT_TOKEN_DUMMY = 'mocked-header.mocked-payload-4.mocked-signature';
 
 export const VERIFICATION_CODE_DUMMY = '1234';
@@ -839,20 +845,4 @@ export const FILE_DUMMY: FileInfo[] = [
 ];
 
 // MSW 프로필 이미지 임시 저장을 위한 변수
-export const PROFILE_IMAGE_DUMMY = [
-  {
-    userId: 1,
-    file: new Blob([], { type: 'image/jpeg' }),
-    uploadName: 'PROFILE_IMAGE_UUID_1.jpg',
-  },
-  {
-    userId: 2,
-    file: new Blob([], { type: 'image/jpeg' }),
-    uploadName: 'PROFILE_IMAGE_UUID_2.jpg',
-  },
-  {
-    userId: 3,
-    file: new Blob([], { type: 'image/png' }),
-    uploadName: 'PROFILE_IMAGE_UUID_3.jpg',
-  },
-];
+export const PROFILE_IMAGE_DUMMY: ImageInfo[] = [];

--- a/src/mocks/services/userServiceHandler.ts
+++ b/src/mocks/services/userServiceHandler.ts
@@ -1,5 +1,12 @@
 import { http, HttpResponse } from 'msw';
-import { JWT_TOKEN_DUMMY, ROLE_DUMMY, TEAM_DUMMY, TEAM_USER_DUMMY, USER_DUMMY } from '@mocks/mockData';
+import {
+  JWT_TOKEN_DUMMY,
+  PROFILE_IMAGE_DUMMY,
+  ROLE_DUMMY,
+  TEAM_DUMMY,
+  TEAM_USER_DUMMY,
+  USER_DUMMY,
+} from '@mocks/mockData';
 import { NICKNAME_REGEX } from '@constants/regex';
 import { convertTokenToUserId } from '@utils/converter';
 import type { Team } from '@/types/TeamType';
@@ -51,19 +58,57 @@ const userServiceHandler = [
 
     return HttpResponse.json(userInfo, { status: 200 });
   }),
-  // 유저 검색 API
-  http.get(`${BASE_URL}/user/search`, ({ request }) => {
-    const url = new URL(request.url);
-    const nickname = url.searchParams.get('nickname');
+  // 유저 프로필 이미지 업로드 API
+  http.post(`${BASE_URL}/user/profile/image`, async ({ request }) => {
     const accessToken = request.headers.get('Authorization');
-
     if (!accessToken) return new HttpResponse(null, { status: 401 });
 
-    // 접두사(nickname)과 일치하는 유저 정보 최대 5명 추출
-    const prefixRegex = new RegExp(`^${nickname}`);
-    const filteredUsers = USER_DUMMY.filter((user) => prefixRegex.test(user.nickname)).slice(0, 5);
+    const formData = await request.formData();
+    const file = formData.get('file');
 
-    return HttpResponse.json(filteredUsers);
+    if (!file) return new HttpResponse(null, { status: 400 });
+    if (!(file instanceof File)) return new HttpResponse('업로드된 문서는 파일이 아닙니다.', { status: 400 });
+
+    let userId;
+    // ToDo: 추후 삭제
+    if (accessToken === JWT_TOKEN_DUMMY) {
+      const payload = JWT_TOKEN_DUMMY.split('.')[1];
+      userId = Number(payload.replace('mocked-payload-', ''));
+    } else {
+      // 토큰에서 userId 추출
+      userId = convertTokenToUserId(accessToken);
+    }
+
+    const userIndex = userId ? USER_DUMMY.findIndex((user) => user.userId === userId) : -1;
+
+    if (!userId || userIndex === -1) {
+      return HttpResponse.json(
+        { message: '해당 사용자를 찾을 수 없습니다. 입력 정보를 확인해 주세요.' },
+        { status: 401 },
+      );
+    }
+
+    const uploadName = `PROFILE_IMAGE_UUID_${PROFILE_IMAGE_DUMMY.length + 1}.jpg`;
+
+    const profileImageIndex = PROFILE_IMAGE_DUMMY.findIndex((user) => user.userId === userId);
+    if (profileImageIndex !== -1) {
+      PROFILE_IMAGE_DUMMY[profileImageIndex].uploadName = uploadName;
+    } else {
+      PROFILE_IMAGE_DUMMY.push({
+        userId,
+        file: new Blob([file], { type: file.type }),
+        uploadName,
+      });
+    }
+
+    console.log(PROFILE_IMAGE_DUMMY);
+
+    // URL 경로 설정
+    const imageUrl = `${BASE_URL}/images/${uploadName}`;
+
+    USER_DUMMY[userIndex].profileImageName = imageUrl;
+
+    return HttpResponse.json({ imageUrl }, { status: 200 });
   }),
   // 가입한 팀 목록 조회 API
   http.get(`${BASE_URL}/user/team`, ({ request }) => {

--- a/src/mocks/services/userServiceHandler.ts
+++ b/src/mocks/services/userServiceHandler.ts
@@ -37,7 +37,7 @@ const userServiceHandler = [
 
     const userIndex = userId ? USER_DUMMY.findIndex((user) => user.userId === userId) : -1;
 
-    if (!userId || userIndex === -1) {
+    if (userIndex === -1) {
       return HttpResponse.json(
         { message: '해당 사용자를 찾을 수 없습니다. 입력 정보를 확인해 주세요.' },
         { status: 401 },
@@ -125,19 +125,15 @@ const userServiceHandler = [
     USER_DUMMY[userIndex].profileImageName = uploadName;
 
     // 프로필 이미지 더미 데이터 추가
-    try {
-      const profileImageIndex = PROFILE_IMAGE_DUMMY.findIndex((user) => user.userId === userId);
-      if (profileImageIndex !== -1) {
-        PROFILE_IMAGE_DUMMY[profileImageIndex].uploadName = uploadName;
-      } else {
-        PROFILE_IMAGE_DUMMY.push({
-          userId,
-          file: new Blob([file], { type: file.type }),
-          uploadName,
-        });
-      }
-    } catch (error) {
-      return HttpResponse.json({ message: '프로필 이미지 저장 중 오류가 발생했습니다.' }, { status: 500 });
+    const profileImageIndex = PROFILE_IMAGE_DUMMY.findIndex((user) => user.userId === userId);
+    if (profileImageIndex !== -1) {
+      PROFILE_IMAGE_DUMMY[profileImageIndex].uploadName = uploadName;
+    } else {
+      PROFILE_IMAGE_DUMMY.push({
+        userId,
+        file: new Blob([file], { type: file.type }),
+        uploadName,
+      });
     }
 
     return HttpResponse.json(null, { status: 200 });

--- a/src/mocks/services/userServiceHandler.ts
+++ b/src/mocks/services/userServiceHandler.ts
@@ -140,7 +140,7 @@ const userServiceHandler = [
       });
     }
 
-    return HttpResponse.json(null, { status: 200 });
+    return HttpResponse.json({ imageName: uploadName }, { status: 200 });
   }),
   // 전체 팀 목록 조회 API (가입한 팀, 대기중인 팀)
   http.get(`${BASE_URL}/user/team`, ({ request }) => {

--- a/src/mocks/services/userServiceHandler.ts
+++ b/src/mocks/services/userServiceHandler.ts
@@ -92,6 +92,9 @@ const userServiceHandler = [
     const { fileName, extension } = fileNameParser(file.name);
     const uploadName = extension ? `${fileName}_${Date.now()}.${extension}` : `${fileName}_${Date.now()}`;
 
+    // 유저 정보에 이미지 추가
+    USER_DUMMY[userIndex].profileImageName = uploadName;
+
     // 프로필 이미지 더미 데이터 추가
     const profileImageIndex = PROFILE_IMAGE_DUMMY.findIndex((user) => user.userId === userId);
     if (profileImageIndex !== -1) {
@@ -103,9 +106,6 @@ const userServiceHandler = [
         uploadName,
       });
     }
-
-    // 유저 정보에 이미지 링크 추가 (UUID.extension)
-    USER_DUMMY[userIndex].profileImageName = uploadName;
 
     return HttpResponse.json(null, { status: 200 });
   }),

--- a/src/mocks/services/userServiceHandler.ts
+++ b/src/mocks/services/userServiceHandler.ts
@@ -9,6 +9,7 @@ import {
 } from '@mocks/mockData';
 import { NICKNAME_REGEX } from '@constants/regex';
 import { convertTokenToUserId } from '@utils/converter';
+import { fileNameParser } from '@utils/fileNameParser';
 import type { Team } from '@/types/TeamType';
 import type { Role } from '@/types/RoleType';
 import type { EditUserInfoForm, User } from '@/types/UserType';
@@ -88,8 +89,10 @@ const userServiceHandler = [
       );
     }
 
-    const uploadName = `PROFILE_IMAGE_UUID_${PROFILE_IMAGE_DUMMY.length + 1}.jpg`;
+    const { fileName, extension } = fileNameParser(file.name);
+    const uploadName = extension ? `${fileName}_${Date.now()}.${extension}` : `${fileName}_${Date.now()}`;
 
+    // 프로필 이미지 더미 데이터 추가
     const profileImageIndex = PROFILE_IMAGE_DUMMY.findIndex((user) => user.userId === userId);
     if (profileImageIndex !== -1) {
       PROFILE_IMAGE_DUMMY[profileImageIndex].uploadName = uploadName;
@@ -101,14 +104,10 @@ const userServiceHandler = [
       });
     }
 
-    console.log(PROFILE_IMAGE_DUMMY);
+    // 유저 정보에 이미지 링크 추가 (UUID.extension)
+    USER_DUMMY[userIndex].profileImageName = uploadName;
 
-    // URL 경로 설정
-    const imageUrl = `${BASE_URL}/images/${uploadName}`;
-
-    USER_DUMMY[userIndex].profileImageName = imageUrl;
-
-    return HttpResponse.json({ imageUrl }, { status: 200 });
+    return HttpResponse.json(null, { status: 200 });
   }),
   // 가입한 팀 목록 조회 API
   http.get(`${BASE_URL}/user/team`, ({ request }) => {

--- a/src/mocks/services/userServiceHandler.ts
+++ b/src/mocks/services/userServiceHandler.ts
@@ -96,15 +96,19 @@ const userServiceHandler = [
     USER_DUMMY[userIndex].profileImageName = uploadName;
 
     // 프로필 이미지 더미 데이터 추가
-    const profileImageIndex = PROFILE_IMAGE_DUMMY.findIndex((user) => user.userId === userId);
-    if (profileImageIndex !== -1) {
-      PROFILE_IMAGE_DUMMY[profileImageIndex].uploadName = uploadName;
-    } else {
-      PROFILE_IMAGE_DUMMY.push({
-        userId,
-        file: new Blob([file], { type: file.type }),
-        uploadName,
-      });
+    try {
+      const profileImageIndex = PROFILE_IMAGE_DUMMY.findIndex((user) => user.userId === userId);
+      if (profileImageIndex !== -1) {
+        PROFILE_IMAGE_DUMMY[profileImageIndex].uploadName = uploadName;
+      } else {
+        PROFILE_IMAGE_DUMMY.push({
+          userId,
+          file: new Blob([file], { type: file.type }),
+          uploadName,
+        });
+      }
+    } catch (error) {
+      return HttpResponse.json({ message: '프로필 이미지 저장 중 오류가 발생했습니다.' }, { status: 500 });
     }
 
     return HttpResponse.json(null, { status: 200 });

--- a/src/mocks/services/userServiceHandler.ts
+++ b/src/mocks/services/userServiceHandler.ts
@@ -109,9 +109,13 @@ const userServiceHandler = [
       userId = convertTokenToUserId(accessToken);
     }
 
-    const userIndex = userId ? USER_DUMMY.findIndex((user) => user.userId === userId) : -1;
+    if (!userId) {
+      return HttpResponse.json({ message: '토큰에 포함된 유저 정보가 존재하지 않습니다.' }, { status: 401 });
+    }
 
-    if (!userId || userIndex === -1) {
+    const userIndex = USER_DUMMY.findIndex((user) => user.userId === userId);
+
+    if (userIndex === -1) {
       return HttpResponse.json(
         { message: '해당 사용자를 찾을 수 없습니다. 입력 정보를 확인해 주세요.' },
         { status: 401 },

--- a/src/pages/setting/UserSettingPage.tsx
+++ b/src/pages/setting/UserSettingPage.tsx
@@ -25,7 +25,7 @@ export default function UserSettingPage() {
       profileImageName: userInfoData.profileImageName,
     },
   });
-  const { formState, register, setValue, watch, handleSubmit } = methods;
+  const { formState, register, watch, handleSubmit } = methods;
   const nickname = watch('nickname');
 
   const { checkedNickname, lastCheckedNickname, handleCheckNickname } = useNicknameDuplicateCheck(
@@ -52,10 +52,7 @@ export default function UserSettingPage() {
       <div className="mx-auto max-w-300 py-30">
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
           {/* 프로필 이미지 */}
-          <ProfileImageContainer
-            imageUrl={watch('profileImageName')}
-            setImageUrl={(url: string) => setValue('profileImageName', url)}
-          />
+          <ProfileImageContainer imageUrl={watch('profileImageName')} />
 
           {/* 아이디 */}
           <ValidationInput

--- a/src/pages/setting/UserSettingPage.tsx
+++ b/src/pages/setting/UserSettingPage.tsx
@@ -25,7 +25,7 @@ export default function UserSettingPage() {
       profileImageName: userInfoData.profileImageName,
     },
   });
-  const { formState, register, watch, handleSubmit } = methods;
+  const { formState, register, watch, setValue, handleSubmit } = methods;
   const nickname = watch('nickname');
 
   const { checkedNickname, lastCheckedNickname, handleCheckNickname } = useNicknameDuplicateCheck(
@@ -52,7 +52,10 @@ export default function UserSettingPage() {
       <div className="mx-auto max-w-300 py-30">
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
           {/* 프로필 이미지 */}
-          <ProfileImageContainer imageUrl={watch('profileImageName')} />
+          <ProfileImageContainer
+            imageUrl={watch('profileImageName')}
+            setImageUrl={(url: string) => setValue('profileImageName', url)}
+          />
 
           {/* 아이디 */}
           <ValidationInput

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -17,6 +17,21 @@ export async function updateUserInfo(userInfoForm: EditUserInfoRequest, axiosCon
 }
 
 /**
+ * 유저 프로필 업로드 API
+ *
+ * @export
+ * @async
+ * @param {File} file - 파일 객체
+ * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
+ * @returns {Promise<AxiosResponse<void>>}
+ */
+export async function uploadProfileImage(file: File, axiosConfig: AxiosRequestConfig = {}) {
+  const fileFormData = new FormData();
+  fileFormData.append('file', file);
+  return authAxios.postForm(`/user/profile/image`, fileFormData, axiosConfig);
+}
+
+/**
  * 유저 목록을 검색하는 API
  *
  * @export

--- a/src/stores/useStore.ts
+++ b/src/stores/useStore.ts
@@ -2,7 +2,7 @@ import { create, StateCreator } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { AUTH_SETTINGS } from '@constants/settings';
 import { decrypt, encrypt } from '@utils/cryptoHelper';
-import { EditUserInfoRequest, User } from '@/types/UserType';
+import { EditUserInfoRequest, User, UserProfileImageForm } from '@/types/UserType';
 
 // Auth Slice
 type AuthStore = {
@@ -20,7 +20,7 @@ type AuthStore = {
 type UserStore = {
   userInfo: User;
   setUserInfo: (newUserInfo: User) => void;
-  editUserInfo: (newUserInfo: EditUserInfoRequest) => void;
+  editUserInfo: (newUserInfo: EditUserInfoRequest | UserProfileImageForm) => void;
   clearUserInfo: () => void;
 };
 
@@ -90,7 +90,7 @@ const createUserSlice: StateCreator<Store, [], [], UserStore> = (set) => ({
       userInfo: newUserInfo,
     }),
 
-  editUserInfo: (newUserInfo: EditUserInfoRequest) =>
+  editUserInfo: (newUserInfo: EditUserInfoRequest | UserProfileImageForm) =>
     set((state) => ({
       userInfo: { ...state.userInfo, ...newUserInfo },
     })),

--- a/src/types/UserType.tsx
+++ b/src/types/UserType.tsx
@@ -17,6 +17,8 @@ export type UserInfo = User & {
   password: string | null;
 };
 
+export type UserProfileImageForm = Pick<User, 'profileImageName'>;
+
 export type SearchUser = Pick<User, 'userId' | 'nickname'>;
 export type UserWithRole = SearchUser & Pick<Role, 'roleName'>;
 

--- a/src/utils/queryKeyGenerator.ts
+++ b/src/utils/queryKeyGenerator.ts
@@ -4,6 +4,7 @@ import type { Project } from '@/types/ProjectType';
 
 export const queryKeys = {
   userInfo: 'userInfo',
+  profileImage: 'profileImage',
   users: 'users',
   teams: 'teams',
   projects: 'projects',
@@ -22,6 +23,16 @@ export const queryKeys = {
  */
 export function generateUserInfoQueryKey() {
   return [queryKeys.userInfo];
+}
+
+/**
+ * 유저 프로필 이미지 queryKey 생성 함수
+ *
+ * @export
+ * @returns {(string | number)[]}
+ */
+export function generateProfileFileQueryKey(userId: number) {
+  return [queryKeys.profileImage, userId];
 }
 
 /**


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해 주세요. -->

- [x] **\[Feat\]** 새로운 기능을 추가했어요.

## Related Issues

<!--#을 눌러 이슈와 연결해 주세요-->
- close #211

## What does this PR do?

<!--무엇을 하셨나요?-->

- [x] 프로필 이미지 업로드 API 구현
- [x] 테스트

## View
![성공](https://github.com/user-attachments/assets/1d07d4db-b7c5-4fc4-84c0-16ecf4233d29)

**데이터 저장 결과 화면**
![image](https://github.com/user-attachments/assets/32f0b965-c4a3-4728-bdd5-99688e61cbca)

## Other information

<!--참고한 자료, 추가적인 사항, 기타 의견-->
- 프론트측에서는 로그인과 함께 유저의 정보를 가져오고, 이후의 유저 정보 변경사항은 zustand 스토어의 유저 정보를 변경하는 방식으로 처리하고 있습니다.
- 유저 프로필 이미지에는 서버가 내려주는 UUID 정보가 저장되고, 이를 로그인과 동시에 받아오고 있습니다.
- 그런데 이미지 변경 시, 서버에서 저장하는 UUID의 정보를 프론트측에서 알 수가 없기 때문에 변경된 이미지 UUID 정보를 zustand 스토어에 저장하는 데 어려움이 있는 상황입니다.😭 이미지 파일 때문에 유저 정보 조회 API를 한번 더 요청하는 것도 좀 과한 처리 같아서 우선 해당 내용은 주석 처리를 해두었으며, 적합한 해결 방법을 알게 된다면 다음 PR에 추가하도록 하겠습니다. (방법을 알고 계신다면 조언을 부탁 드립니다🙇‍♂️)
![image](https://github.com/user-attachments/assets/507561c8-5d2e-4c99-a9b8-34a37304b1cf)