### PR TITLE
Fix: #222 인증여부에 따라 헤더의 문구와 로그아웃 버튼 노출하도록 수정

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -42,15 +42,13 @@ export default function Header() {
         <NavLink to="/setting/user" className="ml-10 hover:brightness-90">
           {({ isActive }) => <FaUserCircle className={`size-20 ${isActive ? 'text-selected' : 'text-white'}`} />}
         </NavLink>
-        {isAuthenticated && (
-          <button
-            type="button"
-            className="ml-10 h-20 rounded-md bg-white px-4 tracking-tight hover:brightness-90"
-            onClick={handleLogout}
-          >
-            Logout
-          </button>
-        )}
+        <button
+          type="button"
+          className="ml-10 h-20 rounded-md bg-white px-4 tracking-tight hover:brightness-90"
+          onClick={isAuthenticated ? handleLogout : () => navigate('/signin', { replace: true })}
+        >
+          {isAuthenticated ? 'Logout' : 'Login'}
+        </button>
       </nav>
     </header>
   );

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -45,7 +45,7 @@ export default function Header() {
         <button
           type="button"
           className="ml-10 h-20 rounded-md bg-white px-4 tracking-tight hover:brightness-90"
-          onClick={isAuthenticated ? handleLogout : () => navigate('/signin', { replace: true })}
+          onClick={isAuthenticated ? handleLogout : () => navigate('/signin')}
         >
           {isAuthenticated ? 'Logout' : 'Login'}
         </button>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -7,7 +7,7 @@ import { logout } from '@services/authService';
 import useToast from '@hooks/useToast';
 
 export default function Header() {
-  const { userInfo: userInfoData, onLogout, clearUserInfo } = useStore();
+  const { userInfo: userInfoData, onLogout, clearUserInfo, isAuthenticated } = useStore();
   const navigate = useNavigate();
   const { toastSuccess } = useToast();
 
@@ -33,20 +33,24 @@ export default function Header() {
         </Link>
       </div>
       <nav className="flex items-center">
-        <div className="tracking-tight text-white">{userInfoData.nickname}님의 Grow Up! 응원합니다.</div>
+        {isAuthenticated && (
+          <div className="tracking-tight text-white">{userInfoData.nickname}님의 Grow Up! 응원합니다.</div>
+        )}
         <NavLink to="/" className="ml-10 hover:brightness-90">
           {({ isActive }) => <FiHome className={`size-20 ${isActive ? 'text-selected' : 'text-white'}`} />}
         </NavLink>
         <NavLink to="/setting/user" className="ml-10 hover:brightness-90">
           {({ isActive }) => <FaUserCircle className={`size-20 ${isActive ? 'text-selected' : 'text-white'}`} />}
         </NavLink>
-        <button
-          type="button"
-          className="ml-10 h-20 rounded-md bg-white px-4 tracking-tight hover:brightness-90"
-          onClick={handleLogout}
-        >
-          Logout
-        </button>
+        {isAuthenticated && (
+          <button
+            type="button"
+            className="ml-10 h-20 rounded-md bg-white px-4 tracking-tight hover:brightness-90"
+            onClick={handleLogout}
+          >
+            Logout
+          </button>
+        )}
       </nav>
     </header>
   );

--- a/src/mocks/services/authServiceHandler.ts
+++ b/src/mocks/services/authServiceHandler.ts
@@ -278,15 +278,8 @@ const authServiceHandler = [
 
   // 로그아웃 API
   http.post(`${BASE_URL}/user/logout`, async ({ cookies }) => {
-    const { refreshToken, refreshTokenExpiresAt } = cookies;
+    const { refreshToken } = cookies;
     const currentTime = Date.now();
-
-    if (!refreshToken || !refreshTokenExpiresAt) {
-      return HttpResponse.json(
-        { message: '리프레시 토큰이 유효하지 않습니다. 다시 로그인해 주세요.' },
-        { status: 401 },
-      );
-    }
 
     return new HttpResponse(null, {
       status: 200,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해 주세요. -->

- [x] **\[Fix\]** 버그를 수정했어요.

## Related Issues

<!--#을 눌러 이슈와 연결해 주세요-->
- close #222 

## What does this PR do?

<!--무엇을 하셨나요?-->

- [x] 로그인되지 않은 사용자에게 헤더의 로그아웃 버튼 노출되는 문제를 해결
- [x] 로그아웃 API의 토큰 인증 로직 삭제

## View
**로그인 진행 시**
![image](https://github.com/user-attachments/assets/f1dc4847-12f1-4112-8559-e1c2a0c1741b)

**로그인되지 않은 유저**
![image](https://github.com/user-attachments/assets/38a78734-0725-4068-9074-165a50f3ee5b)


## Other information

<!--참고한 자료, 추가적인 사항, 기타 의견-->
Zustand에 저장된 `isAutheticated` 속성을 이용해 헤더의 정보를 노출하도록 처리하였습니다!
