### PR TITLE
Feat: #228 유저 인증을 위한 MSW 수정 및 페이지 라우트 인증 처리

### DIFF
--- a/src/mocks/services/authServiceHandler.ts
+++ b/src/mocks/services/authServiceHandler.ts
@@ -228,18 +228,10 @@ const authServiceHandler = [
         return HttpResponse.json({ message: '리프레시 토큰이 만료되었습니다.' }, { status: 401 });
       }
 
-      let newAccessToken;
+      const userId = convertTokenToUserId(accessToken);
+      if (!userId) return new HttpResponse(null, { status: 401 });
 
-      // ToDo: 추후 삭제
-      if (accessToken === JWT_TOKEN_DUMMY) {
-        newAccessToken = 'newMockedAccessToken';
-      } else {
-        // 토큰에서 userId 추출하도록 수정
-        const userId = convertTokenToUserId(accessToken);
-        if (!userId) return new HttpResponse(null, { status: 401 });
-
-        newAccessToken = generateDummyToken(userId);
-      }
+      const newAccessToken = generateDummyToken(userId);
 
       // 액세스 토큰 갱신
       return new HttpResponse(null, {
@@ -259,16 +251,8 @@ const authServiceHandler = [
 
     if (!accessToken) return new HttpResponse(null, { status: 401 });
 
-    let userId;
-    // ToDo: 추후 삭제
-    if (accessToken === JWT_TOKEN_DUMMY) {
-      const payload = JWT_TOKEN_DUMMY.split('.')[1];
-      userId = Number(payload.replace('mocked-payload-', ''));
-    } else {
-      // 토큰에서 userId 추출
-      userId = convertTokenToUserId(accessToken);
-      if (!userId) return new HttpResponse(null, { status: 401 });
-    }
+    const userId = convertTokenToUserId(accessToken);
+    if (!userId) return new HttpResponse(null, { status: 401 });
 
     const foundUser = USER_DUMMY.find((user) => user.userId === userId);
     if (!foundUser) return new HttpResponse(null, { status: 404 });
@@ -385,16 +369,8 @@ const authServiceHandler = [
     const accessToken = request.headers.get('Authorization');
     if (!accessToken) return HttpResponse.json({ message: '인증 정보가 존재하지 않습니다.' }, { status: 401 });
 
-    let userId;
-    // ToDo: 추후 삭제
-    if (accessToken === JWT_TOKEN_DUMMY) {
-      const payload = JWT_TOKEN_DUMMY.split('.')[1];
-      userId = Number(payload.replace('mocked-payload-', ''));
-    } else {
-      // 토큰에서 userId 추출
-      userId = convertTokenToUserId(accessToken);
-      if (!userId) return new HttpResponse(null, { status: 401 });
-    }
+    const userId = convertTokenToUserId(accessToken);
+    if (!userId) return new HttpResponse(null, { status: 401 });
 
     const existingUser = USER_DUMMY.find((user) => user.userId === Number(userId));
     if (!existingUser) return HttpResponse.json({ message: '해당 사용자를 찾을 수 없습니다.' }, { status: 404 });

--- a/src/mocks/services/userServiceHandler.ts
+++ b/src/mocks/services/userServiceHandler.ts
@@ -17,15 +17,8 @@ const userServiceHandler = [
 
     const { nickname, bio } = (await request.json()) as EditUserInfoForm;
 
-    let userId;
-    // ToDo: 추후 삭제
-    if (accessToken === JWT_TOKEN_DUMMY) {
-      const payload = JWT_TOKEN_DUMMY.split('.')[1];
-      userId = Number(payload.replace('mocked-payload-', ''));
-    } else {
-      // 토큰에서 userId 추출
-      userId = convertTokenToUserId(accessToken);
-    }
+    // 토큰에서 userId 추출
+    const userId = convertTokenToUserId(accessToken);
 
     const userIndex = userId ? USER_DUMMY.findIndex((user) => user.userId === userId) : -1;
 
@@ -58,15 +51,7 @@ const userServiceHandler = [
 
     const { links } = (await request.json()) as EditUserLinksForm;
 
-    let userId;
-    // ToDo: 추후 삭제
-    if (accessToken === JWT_TOKEN_DUMMY) {
-      const payload = JWT_TOKEN_DUMMY.split('.')[1];
-      userId = Number(payload.replace('mocked-payload-', ''));
-    } else {
-      // 토큰에서 userId 추출
-      userId = convertTokenToUserId(accessToken);
-    }
+    const userId = convertTokenToUserId(accessToken);
 
     const userIndex = userId ? USER_DUMMY.findIndex((user) => user.userId === userId) : -1;
 

--- a/src/routes/AfterLoginRoute.tsx
+++ b/src/routes/AfterLoginRoute.tsx
@@ -3,9 +3,9 @@ import type { PropsWithChildren } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 
 export default function AfterLoginRoute({ children }: PropsWithChildren) {
-  const { isAuthenticated } = useStore();
+  const { isAuthenticated, userInfo } = useStore();
 
-  if (!isAuthenticated) return <Navigate to="/signin" replace />;
+  if (!isAuthenticated && !userInfo.userId) return <Navigate to="/signin" replace />;
 
   return children || <Outlet />;
 }

--- a/src/routes/AfterLoginRoute.tsx
+++ b/src/routes/AfterLoginRoute.tsx
@@ -1,13 +1,9 @@
+import useStore from '@stores/useStore';
 import type { PropsWithChildren } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 
 export default function AfterLoginRoute({ children }: PropsWithChildren) {
-  /**
-   * ToDo: 로그인 기능이 완성되었을 때, 로그인 확인 로직 추가
-   * 로그인 했을 때만, 사용할 수 있도록 경로를 설정하는 컴포넌트, 로그인 상태를 확인해주는 로직이 필요.
-   * AfterLoginRoute BeforeLoginRoute 둘 다 로그인 확인 로직이 필요하므로, 공통 로직을 커스텀 훅으로 추출할 것.
-   */
-  const isAuthenticated = true;
+  const { isAuthenticated } = useStore();
 
   if (!isAuthenticated) return <Navigate to="/signin" replace />;
 

--- a/src/routes/BeforeLoginRoute.tsx
+++ b/src/routes/BeforeLoginRoute.tsx
@@ -1,13 +1,9 @@
+import useStore from '@stores/useStore';
 import type { PropsWithChildren } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 
 export default function BeforeLoginRoute({ children }: PropsWithChildren) {
-  /**
-   * ToDo: 로그인 기능이 완성되었을 때, 로그인 확인 로직 추가
-   * 로그인을 하지 않았을 때만, 사용할 수 있도록 경로를 설정하는 라우트 컴포넌트, 로그인 상태를 확인해주는 로직이 필요.
-   * AfterLoginRoute BeforeLoginRoute 둘 다 로그인 확인 로직이 필요하므로, 공통 로직을 커스텀 훅으로 추출할 것.
-   */
-  const isAuthenticated = false;
+  const { isAuthenticated } = useStore();
 
   if (isAuthenticated) return <Navigate to="/" replace />;
 

--- a/src/routes/BeforeLoginRoute.tsx
+++ b/src/routes/BeforeLoginRoute.tsx
@@ -3,9 +3,9 @@ import type { PropsWithChildren } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 
 export default function BeforeLoginRoute({ children }: PropsWithChildren) {
-  const { isAuthenticated } = useStore();
+  const { isAuthenticated, userInfo } = useStore();
 
-  if (isAuthenticated) return <Navigate to="/" replace />;
+  if (isAuthenticated || userInfo.userId) return <Navigate to="/" replace />;
 
   return children || <Outlet />;
 }

--- a/src/services/axiosProvider.ts
+++ b/src/services/axiosProvider.ts
@@ -35,7 +35,7 @@ export const authAxios = axiosProvider({
 export const Interceptor = ({ children }: InterceptorProps) => {
   const { toastError } = useToast();
   const navigate = useNavigate();
-  const { onLogout, setAccessToken, clearUserInfo } = useStore.getState();
+  const { onLogout, onLogin, clearUserInfo } = useStore.getState();
 
   useEffect(() => {
     // 요청 인터셉터
@@ -75,7 +75,7 @@ export const Interceptor = ({ children }: InterceptorProps) => {
 
             if (!newAccessToken) throw new Error('토큰 발급에 실패했습니다.');
 
-            setAccessToken(newAccessToken.split(' ')[1]);
+            onLogin(newAccessToken.split(' ')[1]);
 
             // 기존 설정 객체에 새로운 액세스 토큰 적용
             originalRequest.headers.Authorization = newAccessToken;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해 주세요. -->

- [x] **\[Feat\]** 새로운 기능을 추가했어요.

## Related Issues

<!--#을 눌러 이슈와 연결해 주세요-->
- close #228 

## What does this PR do?

<!--무엇을 하셨나요?-->

- [x] AfterLoginRoute(접근하기 위해 로그인이 필요한 페이지 라우트)에 유저 인증 추가
- [x] BeforeLoginRoute(로그인이 필요없는 페이지 라우트)에 유저 인증 점검 코드 추가
- [x] 관련 MSW에서 JWT 더미 데이터를 사용하는 코드 삭제


## View
![로그인필요한경로진입](https://github.com/user-attachments/assets/f90baf06-892f-459d-a242-8baa18635a1a)


## Other information

<!--참고한 자료, 추가적인 사항, 기타 의견-->
새로고침 시 zustand 내부의 인증값이 휘발되면서 로그인 페이지로 이동하는 현상이 발생하고 있습니다.
다른 분들 작업을 위해서 일단 작업한 부분만 올리고, 문제가 되는 내용은 내일 다시 PR을 올려 시정하도록 하겠습니다.

**추가 (수정)**
새로고침 시 `isAuthenticated`가 초기화되는 문제가 발생하였습니다.
로그인 후 영속적으로 유지되는 값인 `userInfo` 정보의 `userId`를 이용해 추가적인 체크를 하도록 하여 이를 수정했습니다.
보안적으로 완벽한 방법이 아니라 임시방편이기는 하지만 우선 새로고침 후에도 로그인 화면으로 이동되는 문제는 해결이 되었습니다.
보안적인 문제도 그렇고 현재의 로직은 `isAuthenticated`가 아니라 `userInfo`에 더 의존하고 있기 때문에 기존에 생각했던 로직과 달라진 점이 있습니다. 따라서 방법을 더 찾아보고 추가적인 수정이 필요할 것 같습니다.
