### PR TITLE
Chore: #236 axiosProvider에서 JWT 더미데이터 삭제

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -45,9 +45,9 @@ export default function Header() {
         <button
           type="button"
           className="ml-10 h-20 rounded-md bg-white px-4 tracking-tight hover:brightness-90"
-          onClick={isAuthenticated ? handleLogout : () => navigate('/signin')}
+          onClick={isAuthenticated || userInfoData.userId ? handleLogout : () => navigate('/signin')}
         >
-          {isAuthenticated ? 'Logout' : 'Login'}
+          {isAuthenticated || userInfoData.userId ? 'Logout' : 'Login'}
         </button>
       </nav>
     </header>

--- a/src/services/axiosProvider.ts
+++ b/src/services/axiosProvider.ts
@@ -27,7 +27,6 @@ export const defaultAxios = axiosProvider();
 export const authAxios = axiosProvider({
   headers: {
     'Content-Type': 'application/json',
-    Authorization: JWT_TOKEN_DUMMY,
   },
   withCredentials: true,
 });


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해 주세요. -->

- [x] **\[Chore\]** 빌드 프로세스 변경, 의존성 패키지 업데이트 했어요.

## Related Issues

<!--#을 눌러 이슈와 연결해 주세요-->
- close #236 

## What does this PR do?

<!--무엇을 하셨나요?-->

- [x] axiosProvider에서 JWT 더미데이터 삭제
- [x] Header의 로그인 / 로그아웃 버튼 노출 여부 결정 시 userId 체크를 추가

## Other information

<!--참고한 자료, 추가적인 사항, 기타 의견-->
새로고침 시 `isAuthenticated`가 초기화되면서 헤더에 로그아웃 버튼 대신 로그인 버튼이 노출되는 이슈가 있었습니다.
이를 해결하고자 임시방편으로 이전 PR과 같이 영속 데이터인 userId를 체크하도록 코드를 추가했습니다.
추후 PR에서 새로고침 이슈 해결하면서 이 부분도 수정 진행하도록 하겠습니다!😆
