### PR TITLE
Fix: #238 등록된 프로젝트 상태가 없을 때, 일정 등록을 시도하면 발생하는 문제 해결

### DIFF
--- a/src/components/common/StatusRadio.tsx
+++ b/src/components/common/StatusRadio.tsx
@@ -19,7 +19,7 @@ export default function StatusRadio({ statusFieldName, statusList }: StatusRadio
   return (
     <>
       {/* ToDo: 상태 선택 리팩토링 할 것 */}
-      <div className="flex items-center justify-start gap-4">
+      <div className="flex flex-wrap items-center justify-start gap-4">
         {statusList.map((status) => {
           const { statusId, statusName, colorCode } = status;
           const isChecked = Number(watch(statusFieldName)) === statusId;

--- a/src/components/modal/task/ModalTaskForm.tsx
+++ b/src/components/modal/task/ModalTaskForm.tsx
@@ -77,7 +77,7 @@ export default function ModalTaskForm({ formId, project, taskId, onSubmit }: Mod
   } = methods;
 
   useEffect(() => {
-    if (!isStatusLoading && statusList) {
+    if (!isStatusLoading && statusList.length > 0) {
       setValue('statusId', statusList[0].statusId);
     }
   }, [isStatusLoading, statusList]);

--- a/src/layouts/page/ProjectLayout.tsx
+++ b/src/layouts/page/ProjectLayout.tsx
@@ -9,21 +9,32 @@ import ListSidebar from '@components/sidebar/ListSidebar';
 import ListProject from '@components/sidebar/ListProject';
 import CreateModalTask from '@components/modal/task/CreateModalTask';
 import CreateModalProjectStatus from '@components/modal/project-status/CreateModalProjectStatus';
+import useToast from '@hooks/useToast';
+import { useReadStatuses } from '@hooks/query/useStatusQuery';
 
 export default function ProjectLayout() {
   const { teamId, projectId } = useParams();
   const { projectList, isProjectLoading } = useReadProjects(Number(teamId));
   const { projectUserRoleList, isProjectUserRoleLoading } = useReadProjectUserRoleList(Number(projectId));
+  const { statusList, isStatusLoading } = useReadStatuses(Number(projectId));
   const { showModal: showTaskModal, openModal: openTaskModal, closeModal: closeTaskModal } = useModal();
   const { showModal: showStatusModal, openModal: openStatusModal, closeModal: closeStatusModal } = useModal();
+  const { toastWarn } = useToast();
 
   const project = useMemo(
     () => projectList?.find((project) => project.projectId.toString() === projectId),
     [projectList, projectId],
   );
 
-  if (isProjectLoading || isProjectUserRoleLoading) return <Spinner />;
+  if (isProjectLoading || isProjectUserRoleLoading || isStatusLoading) return <Spinner />;
   if (!project) return <Navigate to="/error" replace />;
+
+  const handleCreateTaskClick = () => {
+    if (statusList.length === 0) {
+      return toastWarn('등록된 프로젝트 상태가 없습니다. 상태를 등록한 이후에 다시 시도해주세요.');
+    }
+    openTaskModal();
+  };
 
   return (
     <>
@@ -58,7 +69,7 @@ export default function ProjectLayout() {
                 </li>
               </ul>
               <div className="text-main *:ml-10">
-                <button type="button" className="outline-none" onClick={openTaskModal}>
+                <button type="button" className="outline-none" onClick={handleCreateTaskClick}>
                   + 할일 추가
                 </button>
                 <button type="button" className="outline-none" onClick={openStatusModal}>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] **\[Fix\]** 버그를 수정했어요.

## Related Issues
- close #238 

## What does this PR do?
- [x] 일정 등록 모달을 열기 전에 등록된 프로젝트 상태가 있는지 확인하는 로직 추가
- [x] 프로젝트 상태가 길면 개행하도록 `flex-wrap` 속성 추가

## View
![화면 예시 - 상태 없을 시 일정 등록](https://github.com/user-attachments/assets/2dccd2da-675e-40ef-9316-b07fa278a25c)