### PR TITLE
Config: #258 스테이징 환경에 https 설정 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ dist-ssr
 .env.test.local
 .env.production.local
 
+# https local cert
+localhost-key.pem
+localhost.pem
+
 # etc
 .history
 .eslintcache

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "staging": "tsc --project tsconfig.prod.json && vite build --mode staging",
+    "build:staging": "tsc --project tsconfig.prod.json && vite build --mode staging",
+    "serve:staging": "serve -s dist -l 5713 --ssl-cert localhost.pem --ssl-key localhost-key.pem",
     "build": "tsc --project tsconfig.prod.json && vite build",
-    "serve:dist": "serve -s dist -l 5713",
     "lint": "eslint . --ext ts,tsx,js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "test": "vitest --watch",


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] **\[Config\]** 환경설정을 변경했어요.

## Related Issues
- close #258 

## What does this PR do?
- [x] mkcert를 이용하여 인증서 발급하기
- [x] package.json의 명령어를 통해 발급 받은 인증서를 설정하여 스테이징 환경을 실행하도록 수정하기

## Other information
### 참고 자료
**mkcert**
1. [mkcert](https://github.com/FiloSottile/mkcert?tab=readme-ov-file)
2. [mkcert - localhost를 https 환경으로 만들기](https://yung-developer.tistory.com/112)
3. [Next.js, React(vite.js) 로컬 개발 환경 https 적용하기](https://2yh-develop4jeon.tistory.com/88)

**윈도우 패키지 매니저**
1. [윈도우 패키지 매니저 Scoop 설치하기](https://dmowld.tistory.com/32)
2. [Scoop installer](https://github.com/ScoopInstaller/Install#readme)

`mkcert - localhost를 https 환경으로 만들기` 블로그와 `Next.js, React(vite.js) 로컬 개발 환경 https 적용하기` 블로그를 참고하여 로컬에서 https를 인증하는 방법 알아봤습니다.  블로그 내용과 달랐던 점은 webpack을 이용하여 인증서를 설정하거나, vite.config.js 파일의 defineConfig를 통해 https 설정을 추가하지 않는다는 점입니다.

저희는 staging 환경용으로  build를 하고, 만들어진 정적 파일을 serve 라이브러리를 통해 로컬에서 배포하여 테스트 하고 있습니다. 이때 vite를 통해 번들링 하고 있고, vite.config.ts는 build 이후에는 사용할 수 없습니다. 그래서 저희 프로젝트에서는 실제로 빌드된 파일을 서빙하는 serve 라이브러리를 통해 --ssl  옵션으로 설정하여 테스트하고 있습니다.

**스테이징 환경을 사용하실 때 mkcert를 통해 로컬 인증서를 발급하시고 실행해주시기 바랍니다!**

## View
![스크린샷 2024-11-04 172322](https://github.com/user-attachments/assets/689b2df2-b7b6-4ad9-9d35-c561fade00f5)