### PR TITLE
Fix: #266 AT 기간 만료 시 로직 수정

### DIFF
--- a/src/stores/useStore.ts
+++ b/src/stores/useStore.ts
@@ -46,7 +46,6 @@ const createAuthSlice: StateCreator<Store, [], [], AuthStore> = (set) => ({
 
     setTimeout(() => {
       set({
-        isAuthenticated: false,
         accessToken: null,
       });
     }, AUTH_SETTINGS.ACCESS_TOKEN_EXPIRATION);


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해 주세요. -->

- [x] **\[Fix\]** 버그를 수정했어요.

## Related Issues

<!--#을 눌러 이슈와 연결해 주세요-->
- close #266 

## What does this PR do?

<!--무엇을 하셨나요?-->

- [x] 대기상태에서 액세스 토큰이 만료될 시, 액세스 토큰을 자동으로 재발급 받도록 수정


## View
토큰 만료 확인 및 재발급을 5초 주기로 설정한 뒤 테스트하였습니다.
![at만료재발급](https://github.com/user-attachments/assets/abefab32-31c4-4b94-81cb-821003f9c95c)


## Other information

<!--참고한 자료, 추가적인 사항, 기타 의견-->
기존에는 setTimeout으로 인한 액세스 토큰 기간 만료 문제를 해결해야 한다고 생각하고 수정을 진행했습니다.
하지만 액세스 토큰 만료 시 새로운 액세스 토큰을 요청할 때 서버에서 만료 시간 역시 새로 받아오기 때문에, 서버와 액세스 토큰 유지 기간을 동기화하기 위해서는 프론트에서 setTimeout으로 체크 중인 만료 시간 역시 초기화하는 게 맞다는 생각이 들었습니다. 따라서 만료 문제는 따로 처리할 필요가 없었기에 기존 로직을 그대로 유지했습니다.😂

대신 대기 상태에서 액세스 토큰 만료기간이 끝나 액세스 토큰이 자연 휘발될 시 새로운 액세스 토큰 요청을 보내고, 새로운 액세스 토큰을 잘 받아오는지 테스트를 진행했습니다. 
기존 로직에 setTimeout으로 인해 `isAuthenticated` 변수가 초기화되는 문제가 존재해서 이를 처리했습니다. 
(`isAuthenticated` 변수는 로그인 내내 true로 유지되어야 하는 변수이므로, setTimeout으로 인한 토큰 만료 시에도 true 값을 유지해야 합니다.)

테스트 결과, 기존에 발생했던 
- 로그아웃 문제 
- 대기 상태의 토큰 만료로 인한 repatch API 요청 실패 에러
이 두 문제도 해결된 것 같은데 혹시 모르니 확인 한번만 부탁드립니다!