### PR TITLE
Fix: #297 팀 목록 페이지 UI 깨짐 수정

### DIFF
--- a/src/components/project/ProjectItem.tsx
+++ b/src/components/project/ProjectItem.tsx
@@ -39,7 +39,7 @@ export default function ProjectItem({ teamId, project }: ProjectItemProps) {
 
   return (
     <>
-      <li key={project.projectId} className="min-w-300 space-y-2 text-sm">
+      <li key={project.projectId} className="min-w-fit space-y-2 text-sm">
         <Link to={`/teams/${teamId}/projects/${project.projectId}`} className="flex h-50 items-center border p-8">
           <div className="flex max-h-full grow">
             <div className="max-h-full w-60 shrink-0">
@@ -47,13 +47,13 @@ export default function ProjectItem({ teamId, project }: ProjectItemProps) {
               <p className="truncate">{project.projectName}</p>
             </div>
 
-            <div className="flex max-h-full max-w-350 flex-col px-4">
+            <div className="flex max-h-full w-180 grow flex-col px-4">
               <small className="text-xs font-bold text-category">desc</small>
               <p className="truncate">{project.content}</p>
             </div>
           </div>
 
-          <div className="mr-6 flex shrink-0 space-x-10">
+          <div className="mr-6 flex w-60 shrink-0 space-x-10">
             <button
               type="button"
               className="flex items-center text-main hover:brightness-50"

--- a/src/layouts/page/TeamLayout.tsx
+++ b/src/layouts/page/TeamLayout.tsx
@@ -31,7 +31,7 @@ export default function TeamLayout() {
         <ListSidebar title="팀 목록" showButton text="팀 생성" onClick={openTeamModal}>
           <ListTeam data={joinedTeamList} targetId={teamId} />
         </ListSidebar>
-        <section className="flex grow flex-col border border-list bg-contents-box">
+        <section className="flex grow flex-col overflow-auto border border-list bg-contents-box">
           {joinedTeamList.length === 0 ? (
             <div className="flex h-full items-center justify-center text-center">
               소속된 팀이 없습니다! <br />


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해 주세요. -->

- [x] **\[Fix\]** 버그를 수정했어요.

## Related Issues

<!--#을 눌러 이슈와 연결해 주세요-->
* close #297 
## What does this PR do?

<!--무엇을 하셨나요?-->

- [x] projectItem 컴포넌트에 프로젝트 목록 기본 크기 설정
- [x] TeamLayout 컴포넌트에 section tag에 overflow 속성 추가

## Other information

<!--참고한 자료, 추가적인 사항, 기타 의견-->
문제의 UI 사진
![스크린샷 2024-12-11 205150](https://github.com/user-attachments/assets/cdeb5a78-0747-4b44-8ab9-b5a587cd4cd6)

수정 UI
![스크린샷 2024-12-11 204943](https://github.com/user-attachments/assets/babba12b-e37c-4d3f-8803-cbbba80ae538)

![스크린샷 2024-12-11 204959](https://github.com/user-attachments/assets/cc23dc58-90a9-4288-926f-d2c93b3ff28c)
