### PR TITLE
Refactor: #310 MSW 처리중 teamService 기능 리팩토링

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,6 +22,7 @@ module.exports = {
     'object-curly-newline': 'off',
     '@typescript-eslint/no-unused-vars': 'warn',
     '@typescript-eslint/no-shadow': 'warn',
+    '@typescript-eslint/no-use-before-define': 'off',
     'no-param-reassign': 'warn',
     'no-return-assign': 'warn',
     'no-unused-vars': 'warn',

--- a/src/mocks/mockAPI.ts
+++ b/src/mocks/mockAPI.ts
@@ -7,17 +7,18 @@ import {
   TASK_DUMMY,
   TASK_FILE_DUMMY,
   TASK_USER_DUMMY,
+  TEAM_DUMMY,
   TEAM_USER_DUMMY,
   USER_DUMMY,
 } from '@mocks/mockData';
 
 import type { Role } from '@/types/RoleType';
 import type { User } from '@/types/UserType';
-import type { Team } from '@/types/TeamType';
-import type { Project, ProjectForm } from '@/types/ProjectType';
+import type { Team, TeamInfoForm } from '@/types/TeamType';
+import type { Project, ProjectInfoForm } from '@/types/ProjectType';
 import type { ProjectStatus, ProjectStatusForm } from '@/types/ProjectStatusType';
 import type { Task, TaskUpdateForm } from '@/types/TaskType';
-import type { ProjectUser, TaskFileForMemory, TaskUser, UploadTaskFile } from '@/types/MockType';
+import type { ProjectUser, TaskFileForMemory, TaskUser, TeamUser, UploadTaskFile } from '@/types/MockType';
 
 /* ===================== 역할(Role) 관련 처리 ===================== */
 
@@ -39,6 +40,10 @@ export function findUser(userId: User['userId']) {
 }
 
 /* ============= 팀에 연결된 유저(Team User) 관련 처리 ============= */
+// 팀과 연결된 유저 생성
+export function createTeamUser(newTeamUser: TeamUser) {
+  TEAM_USER_DUMMY.push(newTeamUser);
+}
 
 // 팀과 연결된 유저 조회
 export function findTeamUser(teamId: Team['teamId'], userId: User['userId']) {
@@ -50,7 +55,58 @@ export function findAllTeamUsers(teamId: Team['teamId']) {
   return TEAM_USER_DUMMY.filter((teamUser) => teamUser.teamId === teamId);
 }
 
+// 특정 팀 유저 수정
+export function updateTeamUser(teamId: Team['teamId'], userId: User['userId'], newRoleId: Role['roleId']) {
+  const teamUser = findTeamUser(teamId, userId);
+  if (!teamUser) throw new Error('팀원을 찾을 수 없습니다.');
+  teamUser.roleId = newRoleId;
+}
+
+// 팀 유저 삭제
+export function deleteTeamUser(teamId: Team['teamId'], userId: User['userId']) {
+  const teamUserIndex = TEAM_USER_DUMMY.findIndex(
+    (teamUser) => teamUser.teamId === teamId && teamUser.userId === userId,
+  );
+  if (teamUserIndex === -1) throw new Error('팀 유저를 찾을 수 없습니다.');
+  TEAM_USER_DUMMY.splice(teamUserIndex, 1);
+}
+
+// 팀에 속한 모든 팀 유저 삭제
+export function deleteAllTeamUser(teamId: Team['teamId']) {
+  const filteredTeamUsers = TEAM_USER_DUMMY.filter((teamUser) => teamUser.teamId !== teamId);
+  if (TEAM_USER_DUMMY.length !== filteredTeamUsers.length) {
+    TEAM_USER_DUMMY.length = 0;
+    TEAM_USER_DUMMY.push(...filteredTeamUsers);
+  }
+}
+
 /* ====================== 팀(Team) 관련 처리 ====================== */
+// 팀 생성
+export function createTeam(newTeam: Team) {
+  TEAM_DUMMY.push(newTeam);
+}
+
+// 팀 조회
+export function findTeam(teamId: Team['teamId']) {
+  return TEAM_DUMMY.find((team) => team.teamId === teamId);
+}
+
+// 팀 수정
+export function updateTeam(teamId: Team['teamId'], updatedTeamInfo: TeamInfoForm) {
+  const team = findTeam(teamId);
+  if (!team) throw new Error('팀를 찾을 수 없습니다.');
+
+  const { teamName, content } = updatedTeamInfo;
+  team.teamName = teamName;
+  team.content = content;
+}
+
+// 팀 삭제
+export function deleteTeam(teamId: Team['teamId']) {
+  const teamIndex = TEAM_DUMMY.findIndex((team) => team.teamId === teamId);
+  if (teamIndex === -1) throw new Error('팀을 찾을 수 없습니다.');
+  TEAM_DUMMY.splice(teamIndex, 1);
+}
 
 /* ========= 프로젝트에 연결된 유저(Project User) 관련 처리 ========= */
 
@@ -67,15 +123,6 @@ export function findProjectUser(projectId: Project['projectId'], userId: User['u
 // 프로젝트의 연결된 모든 유저 조회
 export function findAllProjectUser(projectId: Project['projectId']) {
   return PROJECT_USER_DUMMY.filter((projectUser) => projectUser.projectId === projectId);
-}
-
-// 프로젝트와 연결된 모든 유저 삭제
-export function deleteAllProjectUser(projectId: Project['projectId']) {
-  const filteredProjectUsers = PROJECT_USER_DUMMY.filter((projectUser) => projectUser.projectId !== projectId);
-  if (PROJECT_USER_DUMMY.length !== filteredProjectUsers.length) {
-    PROJECT_USER_DUMMY.length = 0;
-    PROJECT_USER_DUMMY.push(...filteredProjectUsers);
-  }
 }
 
 // 프로젝트 유저의 역할 업데이트
@@ -103,6 +150,28 @@ export function deleteProjectUser(projectId: Project['projectId'], userId: User[
   PROJECT_USER_DUMMY.splice(projectUserIndex, 1);
 }
 
+// 특정 유저에 연결된 모든 프로젝트 삭제
+export function deleteAllProjectUserByTeamId(teamId: Team['teamId'], userId: User['userId']) {
+  const projectIdList = findAllProject(teamId).map((project) => project.projectId);
+
+  const filteredProjectUsers = PROJECT_USER_DUMMY.filter(
+    (projectUser) => !(projectIdList.includes(projectUser.projectId) && projectUser.userId === userId),
+  );
+
+  if (PROJECT_USER_DUMMY.length !== filteredProjectUsers.length) {
+    PROJECT_USER_DUMMY.length = 0;
+    PROJECT_USER_DUMMY.push(...filteredProjectUsers);
+  }
+}
+
+// 프로젝트와 연결된 모든 유저 삭제
+export function deleteAllProjectUser(projectId: Project['projectId']) {
+  const filteredProjectUsers = PROJECT_USER_DUMMY.filter((projectUser) => projectUser.projectId !== projectId);
+  if (PROJECT_USER_DUMMY.length !== filteredProjectUsers.length) {
+    PROJECT_USER_DUMMY.length = 0;
+    PROJECT_USER_DUMMY.push(...filteredProjectUsers);
+  }
+}
 /* ================= 프로젝트(Project) 관련 처리 ================= */
 
 // 프로젝트 생성
@@ -120,22 +189,23 @@ export function findAllProject(teamId: Team['teamId']) {
   return PROJECT_DUMMY.filter((project) => project.teamId === teamId);
 }
 
+// 프로젝트 정보 수정
+export function updateProject(projectId: Project['projectId'], updatedProjectInfo: ProjectInfoForm) {
+  const project = findProject(projectId);
+  if (!project) throw new Error('프로젝트를 찾을 수 없습니다.');
+
+  const { projectName, content, startDate, endDate } = updatedProjectInfo;
+  project.projectName = projectName;
+  project.content = content;
+  project.startDate = new Date(startDate);
+  project.endDate = endDate ? new Date(endDate) : null;
+}
+
 // 프로젝트 삭제
 export function deleteProject(projectId: Project['projectId']) {
   const projectIndex = PROJECT_DUMMY.findIndex((project) => project.projectId === projectId);
   if (projectIndex === -1) throw new Error('프로젝트를 찾을 수 없습니다.');
   PROJECT_DUMMY.splice(projectIndex, 1);
-}
-
-// 프로젝트 정보 수정
-export function updateProject(projectId: Project['projectId'], updatedProjectInfo: ProjectForm) {
-  const project = findProject(projectId);
-  if (!project) throw new Error('프로젝트를 찾을 수 없습니다.');
-
-  project.projectName = updatedProjectInfo.projectName;
-  project.content = updatedProjectInfo.content;
-  project.startDate = new Date(updatedProjectInfo.startDate);
-  project.endDate = updatedProjectInfo.endDate ? new Date(updatedProjectInfo.endDate) : null;
 }
 
 /* ================ 프로젝트 상태(Status) 관련 처리 ================ */

--- a/src/mocks/mockUtils.ts
+++ b/src/mocks/mockUtils.ts
@@ -1,0 +1,28 @@
+import { findRoleByRoleName } from '@mocks/mockAPI';
+import type { Team, TeamCoworkerForm } from '@/types/TeamType';
+import { Project, ProjectCoworkerForm } from '@/types/ProjectType';
+
+// 팀 유저 객체 생성 함수
+export function createTeamUserFormat(coworker: TeamCoworkerForm, newTeamId: Team['teamId'], isPending: boolean) {
+  const role = findRoleByRoleName(coworker.roleName);
+  if (!role) throw new Error('유효하지 않은 역할입니다.');
+
+  return {
+    teamId: newTeamId,
+    userId: coworker.userId,
+    roleId: role.roleId,
+    isPendingApproval: isPending,
+  };
+}
+
+// 프로젝트 유저 객체 생성 함수
+export function createProjectUserFormat(coworker: ProjectCoworkerForm, newProjectId: Project['projectId']) {
+  const role = findRoleByRoleName(coworker.roleName);
+  if (!role) throw new Error('유효하지 않은 역할입니다.');
+
+  return {
+    projectId: newProjectId,
+    userId: coworker.userId,
+    roleId: role.roleId,
+  };
+}

--- a/src/mocks/services/projectServiceHandler.ts
+++ b/src/mocks/services/projectServiceHandler.ts
@@ -10,7 +10,6 @@ import {
   deleteAllTaskUser,
   deleteProject,
   deleteProjectUser,
-  deleteTaskUser,
   findAllProject,
   findAllProjectStatus,
   findAllProjectUser,
@@ -25,9 +24,10 @@ import {
   updateProjectUserRole,
 } from '@mocks/mockAPI';
 import { PROJECT_DUMMY } from '@mocks/mockData';
+import { createProjectUserFormat } from '@mocks/mockUtils';
 import { convertTokenToUserId } from '@utils/converter';
 import type { SearchUser, UserWithRole } from '@/types/UserType';
-import type { Project, ProjectCoworkerForm, ProjectForm } from '@/types/ProjectType';
+import type { Project, ProjectCoworkerForm, ProjectForm, ProjectInfoForm } from '@/types/ProjectType';
 
 const API_URL = import.meta.env.VITE_API_URL;
 let autoIncrementIdForProject = PROJECT_DUMMY.length + 1;
@@ -103,17 +103,22 @@ const projectServiceHandler = [
     };
     createProject(newProject);
 
-    // 프로젝트 유저 연결 생성
-    // ToDo: 중간에 잘못되면 일관성, 정합성을 유지할 수 없음 수정 필요.
-    coworkers.push({ userId, roleName: 'ADMIN' });
-    for (let i = 0; i < coworkers.length; i++) {
-      const coworker = coworkers[i];
-      const role = findRoleByRoleName(coworker.roleName);
-      if (!role) return new HttpResponse(null, { status: 500 });
+    // 프로젝트 유저 연결 생성 (프로젝트 생성자, 프로젝트원)
+    const projectUsers = [];
+    try {
+      const adminCoworker: ProjectCoworkerForm = { userId, roleName: 'ADMIN' };
+      coworkers.push(adminCoworker);
 
-      const { roleId } = role;
-      createProjectUser({ userId: coworker.userId, projectId, roleId });
+      for (let i = 0; i < coworkers.length; i++) {
+        const coworker = coworkers[i];
+        const coworkerProjectUser = createProjectUserFormat(coworker, projectId);
+        projectUsers.push(coworkerProjectUser);
+      }
+    } catch (error) {
+      const { message } = error as Error;
+      return HttpResponse.json({ message }, { status: 404 });
     }
+    projectUsers.forEach((projectUser) => createProjectUser(projectUser));
 
     return new HttpResponse(null, { status: 200 });
   }),
@@ -213,8 +218,8 @@ const projectServiceHandler = [
       });
       deleteAllTask(projectId);
       deleteAllProjectStatus(projectId);
-      deleteProject(projectId);
       deleteAllProjectUser(projectId);
+      deleteProject(projectId);
     } catch (error) {
       console.error((error as Error).message);
       return new HttpResponse(null, { status: 500 });
@@ -228,7 +233,7 @@ const projectServiceHandler = [
     const accessToken = request.headers.get('Authorization');
     const projectId = Number(params.projectId);
     const teamId = Number(params.teamId);
-    const updatedProjectInfo = (await request.json()) as ProjectForm;
+    const updatedProjectInfo = (await request.json()) as ProjectInfoForm;
 
     // 유저 인증 확인
     if (!accessToken) return new HttpResponse(null, { status: 401 });
@@ -267,7 +272,7 @@ const projectServiceHandler = [
   }),
 
   // 프로젝트 팀원 추가 API
-  http.post(`${API_URL}/project/:projectId/user/invitation`, async ({ request, params }) => {
+  http.post(`${API_URL}/project/:projectId/user`, async ({ request, params }) => {
     const accessToken = request.headers.get('Authorization');
     const projectId = Number(params.projectId);
     const { userId: projectCoworkerId, roleName } = (await request.json()) as ProjectCoworkerForm;
@@ -376,7 +381,7 @@ const projectServiceHandler = [
     // 요청한 유저의 역할 확인 (ADMIN 또는 LEADER만 권한 변경 가능)
     const userRole = findRole(projectUser.roleId);
     if (!userRole) {
-      return new HttpResponse('서버 데이터 오류: 역할이 매칭되지 않습니다.', { status: 500 });
+      return new HttpResponse('유효하지 않은 역할입니다.', { status: 404 });
     }
 
     if (userRole.roleName !== 'ADMIN' && userRole.roleName !== 'LEADER') {
@@ -384,15 +389,6 @@ const projectServiceHandler = [
     }
 
     try {
-      const statusIds = findAllProjectStatus(projectId).map((status) => status.statusId);
-
-      statusIds.forEach((statusId) => {
-        const tasks = findAllTask(statusId);
-        tasks.forEach((task) => {
-          deleteTaskUser(task.taskId, projectCoworkerId);
-        });
-      });
-
       deleteProjectUser(projectId, projectCoworkerId);
     } catch (error) {
       console.error((error as Error).message);

--- a/src/mocks/services/taskServiceHandler.ts
+++ b/src/mocks/services/taskServiceHandler.ts
@@ -286,10 +286,8 @@ const taskServiceHandler = [
       const { userId } = taskUsers[i];
 
       const projectUser = findProjectUser(projectId, userId);
-      if (!projectUser) return new HttpResponse(null, { status: 403 });
-
+      const role = projectUser ? findRole(projectUser.roleId) : { roleName: null };
       const user = findUser(userId);
-      const role = findRole(projectUser.roleId);
       if (!user || !role) return new HttpResponse(null, { status: 404 });
 
       const assignee = { userId: user.userId, nickname: user.nickname, roleName: role.roleName };

--- a/src/mocks/services/teamServiceHandler.ts
+++ b/src/mocks/services/teamServiceHandler.ts
@@ -1,22 +1,38 @@
 import { http, HttpResponse } from 'msw';
+import { TEAM_DUMMY } from '@mocks/mockData';
+import { createTeamUserFormat } from '@mocks/mockUtils';
+import { convertTokenToUserId } from '@utils/converter';
 import {
-  PROJECT_DUMMY,
-  PROJECT_USER_DUMMY,
-  STATUS_DUMMY,
-  TASK_DUMMY,
-  TEAM_DUMMY,
-  TEAM_USER_DUMMY,
-  TASK_USER_DUMMY,
-  TASK_FILE_DUMMY,
-  ROLE_DUMMY,
-  USER_DUMMY,
-} from '@mocks/mockData';
-import type { TeamCoworkerForm, TeamForm } from '@/types/TeamType';
-import { convertTokenToUserId } from '@/utils/converter';
-import { findAllTeamUsers, findTeamUser, findUser } from '../mockAPI';
-import { SearchUser } from '@/types/UserType';
+  createTeam,
+  createTeamUser,
+  deleteAllProjectStatus,
+  deleteAllProjectUser,
+  deleteAllProjectUserByTeamId,
+  deleteAllTask,
+  deleteAllTaskFile,
+  deleteAllTaskFileInMemory,
+  deleteAllTaskUser,
+  deleteAllTeamUser,
+  deleteProject,
+  deleteTeam,
+  deleteTeamUser,
+  findAllProject,
+  findAllProjectStatus,
+  findAllTask,
+  findAllTeamUsers,
+  findRole,
+  findRoleByRoleName,
+  findTeamUser,
+  findUser,
+  updateTeam,
+  updateTeamUser,
+} from '@mocks/mockAPI';
+
+import type { SearchUser } from '@/types/UserType';
+import type { Team, TeamCoworkerForm, TeamForm } from '@/types/TeamType';
 
 const API_URL = import.meta.env.VITE_API_URL;
+let autoIncrementIdForTeam = TEAM_DUMMY.length + 1;
 
 const teamServiceHandler = [
   // 팀 소속 유저 검색 API
@@ -37,8 +53,8 @@ const teamServiceHandler = [
     const teamUser = findTeamUser(teamId, userId);
     if (!teamUser) return new HttpResponse(null, { status: 403 });
 
-    // 팀에 속한 모든 유저 검색
-    const teamUsers = findAllTeamUsers(teamId);
+    // 팀에 참여하고 있는 모든 유저 검색
+    const teamUsers = findAllTeamUsers(teamId).filter((teamUser) => teamUser.isPendingApproval === false);
     const searchUsers: SearchUser[] = [];
 
     // 팀 유저 정보 취득
@@ -55,54 +71,46 @@ const teamServiceHandler = [
 
     return HttpResponse.json(matchedSearchUsers);
   }),
+
   // 팀 생성 API
   http.post(`${API_URL}/team`, async ({ request }) => {
     const accessToken = request.headers.get('Authorization');
     const { teamName, content, coworkers } = (await request.json()) as TeamForm;
 
+    // 유저 인증 확인
     if (!accessToken) return new HttpResponse(null, { status: 401 });
 
-    // 유저 아이디 정보 취득
+    // 유저 ID 정보 취득
     const userId = convertTokenToUserId(accessToken);
     if (!userId) return new HttpResponse(null, { status: 401 });
 
-    // 팀 ID 생성 및 팀 추가
-    const newTeamId = TEAM_DUMMY.length + 1;
-    TEAM_DUMMY.push({
+    // 팀 생성
+    const newTeamId = autoIncrementIdForTeam++;
+    const newTeam: Team = {
       teamId: newTeamId,
       creatorId: userId,
       teamName,
       content,
-    });
+    };
+    createTeam(newTeam);
 
-    // 초대된 팀원들 추가
-    const validTeamUsers = [];
-    for (let i = 0; i < coworkers.length; i++) {
-      const coworker = coworkers[i];
-      const role = ROLE_DUMMY.find((role) => role.roleName === coworker.roleName);
+    // 팀 유저 연결 생성 (팀 생성자, 팀원)
+    const teamUsers = [];
+    try {
+      const headCoworker: TeamCoworkerForm = { userId, roleName: 'HEAD' };
+      const headTeamUser = createTeamUserFormat(headCoworker, newTeamId, false);
+      teamUsers.push(headTeamUser);
 
-      if (!role) return HttpResponse.json({ message: '유효하지 않은 역할입니다.' }, { status: 400 });
-
-      validTeamUsers.push({
-        teamId: newTeamId,
-        userId: coworker.userId,
-        roleId: role.roleId,
-        isPendingApproval: true,
-      });
+      for (let i = 0; i < coworkers.length; i++) {
+        const coworker = coworkers[i];
+        const coworkerTeamUser = createTeamUserFormat(coworker, newTeamId, true);
+        teamUsers.push(coworkerTeamUser);
+      }
+    } catch (error) {
+      const { message } = error as Error;
+      return HttpResponse.json({ message }, { status: 404 });
     }
-    TEAM_USER_DUMMY.push(...validTeamUsers);
-
-    // 팀 생성자도 자동으로 팀에 추가
-    const creatorRole = ROLE_DUMMY.find((role) => role.roleName === 'HEAD');
-
-    if (!creatorRole) return HttpResponse.json({ message: '유효하지 않은 역할입니다.' }, { status: 404 });
-
-    TEAM_USER_DUMMY.push({
-      teamId: newTeamId,
-      userId,
-      roleId: creatorRole.roleId,
-      isPendingApproval: false,
-    });
+    teamUsers.forEach((teamUser) => createTeamUser(teamUser));
 
     return new HttpResponse(null, {
       status: 201,
@@ -115,7 +123,8 @@ const teamServiceHandler = [
   // 팀 탈퇴 API
   http.post(`${API_URL}/team/:teamId/leave`, ({ request, params }) => {
     const accessToken = request.headers.get('Authorization');
-    const { teamId } = params;
+    const teamId = Number(params.teamId);
+
     // 유저 인증 확인
     if (!accessToken) return new HttpResponse(null, { status: 401 });
 
@@ -123,34 +132,11 @@ const teamServiceHandler = [
     const userId = convertTokenToUserId(accessToken);
     if (!userId) return new HttpResponse(null, { status: 401 });
 
-    const filteredTeamUsers = TEAM_USER_DUMMY.filter(
-      (teamUser) => !(teamUser.teamId === Number(teamId) && teamUser.userId === Number(userId)),
-    );
+    // 팀내 소속된 모든 프로젝트에서 삭제
+    deleteAllProjectUserByTeamId(teamId, userId);
 
-    TEAM_USER_DUMMY.length = 0;
-    TEAM_USER_DUMMY.push(...filteredTeamUsers);
-
-    const projectIds = PROJECT_DUMMY.filter((project) => project.teamId === Number(teamId)).map(
-      (project) => project.projectId,
-    );
-
-    const filteredProjectUsers = PROJECT_USER_DUMMY.filter(
-      (projectUser) => !(projectIds.includes(projectUser.projectId) && projectUser.userId === Number(userId)),
-    );
-
-    PROJECT_USER_DUMMY.length = 0;
-    PROJECT_USER_DUMMY.push(...filteredProjectUsers);
-
-    // TODO: 리팩토링 필요
-    const filteredTaskUsers = TASK_USER_DUMMY.filter((taskUser) => {
-      const task = TASK_DUMMY.find((task) => task.taskId === taskUser.taskId);
-      const statusId = task ? task.statusId : undefined;
-      const projectId = statusId ? STATUS_DUMMY.find((status) => status.statusId === statusId)?.projectId : undefined;
-
-      return !(projectId && projectIds.includes(projectId) && taskUser.userId === Number(userId));
-    });
-    TASK_USER_DUMMY.length = 0;
-    TASK_USER_DUMMY.push(...filteredTaskUsers);
+    // 팀에서 삭제
+    deleteTeamUser(teamId, userId);
 
     return new HttpResponse(null, { status: 204 });
   }),
@@ -158,57 +144,58 @@ const teamServiceHandler = [
   // 팀 삭제 API
   http.delete(`${API_URL}/team/:teamId`, ({ request, params }) => {
     const accessToken = request.headers.get('Authorization');
-    const { teamId } = params;
+    const teamId = Number(params.teamId);
 
+    // 유저 인증 확인
     if (!accessToken) return new HttpResponse(null, { status: 401 });
 
-    const filteredTeams = TEAM_DUMMY.filter((team) => team.teamId !== Number(teamId));
-    TEAM_DUMMY.length = 0;
-    TEAM_DUMMY.push(...filteredTeams);
+    // 유저 ID 정보 취득
+    const userId = convertTokenToUserId(accessToken);
+    if (!userId) return new HttpResponse(null, { status: 401 });
 
-    const filteredTeamUsers = TEAM_USER_DUMMY.filter((teamUser) => teamUser.teamId !== Number(teamId));
-    TEAM_USER_DUMMY.length = 0;
-    TEAM_USER_DUMMY.push(...filteredTeamUsers);
+    // 팀 소속 확인
+    const teamUser = findTeamUser(teamId, userId);
+    if (!teamUser) return new HttpResponse(null, { status: 403 });
 
-    const projectIdsToDelete = PROJECT_DUMMY.filter((project) => project.teamId === Number(teamId)).map(
-      (project) => project.projectId,
-    );
+    // 팀 내 권한 확인
+    const role = findRole(teamUser.roleId);
+    if (!role) return new HttpResponse(null, { status: 500 });
+    if (role.roleName !== 'HEAD') return new HttpResponse(null, { status: 403 });
 
-    const statusIdsToDelete = STATUS_DUMMY.filter((status) => projectIdsToDelete.includes(status.projectId)).map(
-      (status) => status.statusId,
-    );
+    // 팀에 속한 모든 프로젝트 ID 정보 취득
+    const projectIdsToDelete = findAllProject(teamId).map((project) => project.projectId);
 
-    const filteredProjects = PROJECT_DUMMY.filter((project) => !projectIdsToDelete.includes(project.projectId));
-    PROJECT_DUMMY.length = 0;
-    PROJECT_DUMMY.push(...filteredProjects);
+    // 프로젝트에 속한 모든 프로젝트 상태 ID 정보 취득
+    const statusIdsToDelete = projectIdsToDelete
+      .map((projectId) => findAllProjectStatus(projectId).map((status) => status.statusId))
+      .flat();
 
-    const filteredStatuses = STATUS_DUMMY.filter((status) => !statusIdsToDelete.includes(status.statusId));
-    STATUS_DUMMY.length = 0;
-    STATUS_DUMMY.push(...filteredStatuses);
+    // 프로젝트에 속한 모든 일정 ID 정보 취득
+    const taskIdsToDelete = statusIdsToDelete
+      .map((statusId) => findAllTask(statusId).map((task) => task.taskId))
+      .flat();
 
-    const filteredTasks = TASK_DUMMY.filter((task) => !statusIdsToDelete.includes(task.statusId));
-    TASK_DUMMY.length = 0;
-    TASK_DUMMY.push(...filteredTasks);
+    // 팀 삭제(순서 중요)
+    try {
+      taskIdsToDelete.forEach((taskId) => {
+        deleteAllTaskFileInMemory(taskId);
+        deleteAllTaskFile(taskId);
+        deleteAllTaskUser(taskId);
+      });
 
-    const filteredTaskFiles = TASK_FILE_DUMMY.filter((taskFile) => {
-      const task = TASK_DUMMY.find((task) => task.taskId === taskFile.taskId);
-      const statusId = task ? task.statusId : undefined;
-      const projectId = statusId ? STATUS_DUMMY.find((status) => status.statusId === statusId)?.projectId : undefined;
-      return !(projectId && projectIdsToDelete.includes(projectId));
-    });
+      projectIdsToDelete.forEach((projectId) => {
+        deleteAllTask(projectId);
+        deleteAllProjectStatus(projectId);
+        deleteAllProjectUser(projectId);
+        deleteProject(projectId);
+      });
 
-    TASK_FILE_DUMMY.length = 0;
-    TASK_FILE_DUMMY.push(...filteredTaskFiles);
-
-    const filteredTaskUsers = TASK_USER_DUMMY.filter((taskUser) => {
-      const task = TASK_DUMMY.find((task) => task.taskId === taskUser.taskId);
-      const statusId = task ? task.statusId : undefined;
-      const projectId = statusId ? STATUS_DUMMY.find((status) => status.statusId === statusId)?.projectId : undefined;
-      return !(projectId && projectIdsToDelete.includes(projectId));
-    });
-
-    TASK_USER_DUMMY.length = 0;
-    TASK_USER_DUMMY.push(...filteredTaskUsers);
+      deleteAllTeamUser(teamId);
+      deleteTeam(teamId);
+    } catch (error) {
+      console.error((error as Error).message);
+      return new HttpResponse(null, { status: 500 });
+    }
 
     return new HttpResponse(null, { status: 204 });
   }),
@@ -216,7 +203,7 @@ const teamServiceHandler = [
   // 팀 초대 수락 API
   http.post(`${API_URL}/team/:teamId/invitation/accept`, ({ request, params }) => {
     const accessToken = request.headers.get('Authorization');
-    const { teamId } = params;
+    const teamId = Number(params.teamId);
 
     // 유저 인증 확인
     if (!accessToken) return new HttpResponse(null, { status: 401 });
@@ -225,50 +212,59 @@ const teamServiceHandler = [
     const userId = convertTokenToUserId(accessToken);
     if (!userId) return new HttpResponse(null, { status: 401 });
 
-    const teamUser = TEAM_USER_DUMMY.find(
-      (teamUser) => teamUser.teamId === Number(teamId) && teamUser.userId === Number(userId),
-    );
+    // 팀 초대 수락
+    const teamUser = findTeamUser(teamId, userId);
+    if (!teamUser) {
+      return HttpResponse.json({ message: '요청 유저에 대한 초대 내역을 찾을 수 없습니다.' }, { status: 500 });
+    }
+    teamUser.isPendingApproval = false;
 
-    if (teamUser) teamUser.isPendingApproval = false;
     return new HttpResponse(null, { status: 200 });
   }),
 
   // 팀 초대 거절 API
   http.post(`${API_URL}/team/:teamId/invitation/decline`, ({ request, params }) => {
     const accessToken = request.headers.get('Authorization');
-    const { teamId } = params;
+    const teamId = Number(params.teamId);
 
     // 유저 인증 확인
-    if (!accessToken) return new HttpResponse(null, { status: 403 });
+    if (!accessToken) return new HttpResponse(null, { status: 401 });
 
-    // 유저 아이디 정보 취득
+    // 유저 ID 정보 취득
     const userId = convertTokenToUserId(accessToken);
     if (!userId) return new HttpResponse(null, { status: 401 });
 
-    const filteredTeamUsers = TEAM_USER_DUMMY.filter(
-      (teamUser) => !(teamUser.teamId === Number(teamId) && teamUser.userId === Number(userId)),
-    );
-
-    TEAM_USER_DUMMY.length = 0;
-    TEAM_USER_DUMMY.push(...filteredTeamUsers);
+    // 팀 초대 거절
+    try {
+      deleteTeamUser(teamId, userId);
+    } catch (error) {
+      const { message } = error as Error;
+      return HttpResponse.json({ message }, { status: 404 });
+    }
 
     return new HttpResponse(null, { status: 200 });
   }),
 
   // 팀원 목록 조회 API
+  // ToDo: 응답에 isPendingApproval 추가하기
   http.get(`${API_URL}/team/:teamId/user`, ({ request, params }) => {
     const accessToken = request.headers.get('Authorization');
-    const { teamId } = params;
+    const teamId = Number(params.teamId);
 
-    if (!accessToken) {
-      return new HttpResponse(null, { status: 401 });
-    }
+    // 유저 인증 확인
+    if (!accessToken) return new HttpResponse(null, { status: 401 });
 
-    const teamMembers = TEAM_USER_DUMMY.filter((teamUser) => teamUser.teamId === Number(teamId));
+    // 유저 ID 정보 취득
+    const userId = convertTokenToUserId(accessToken);
+    if (!userId) return new HttpResponse(null, { status: 401 });
 
-    const membersData = teamMembers.map((member) => {
-      const role = ROLE_DUMMY.find((role) => role.roleId === member.roleId);
-      const user = USER_DUMMY.find((user) => user.userId === member.userId);
+    // 모든 팀원 조회
+    const teamUsers = findAllTeamUsers(teamId);
+
+    // 팀원 정보 조회
+    const memberInfo = teamUsers.map((teamUser) => {
+      const user = findUser(teamUser.userId);
+      const role = findRole(teamUser.roleId);
 
       return {
         userId: user?.userId,
@@ -277,25 +273,29 @@ const teamServiceHandler = [
       };
     });
 
-    return HttpResponse.json(membersData);
+    return HttpResponse.json(memberInfo);
   }),
 
   // 팀 정보 수정 API
   http.patch(`${API_URL}/team/:teamId`, async ({ request, params }) => {
     const accessToken = request.headers.get('Authorization');
-    const { teamId } = params;
-    const { teamName, content } = (await request.json()) as TeamForm;
+    const teamId = Number(params.teamId);
+    const updatedTeamInfo = (await request.json()) as TeamForm;
 
+    // 유저 인증 확인
     if (!accessToken) return new HttpResponse(null, { status: 401 });
 
-    const teamIndex = TEAM_DUMMY.findIndex((team) => team.teamId === Number(teamId));
+    // 유저 ID 정보 취득
+    const userId = convertTokenToUserId(accessToken);
+    if (!userId) return new HttpResponse(null, { status: 401 });
 
-    if (teamIndex === -1) {
-      return HttpResponse.json({ message: '팀을 찾을 수 없습니다.' }, { status: 404 });
+    // 팀 정보 수정
+    try {
+      updateTeam(teamId, updatedTeamInfo);
+    } catch (error) {
+      const { message } = error as Error;
+      return HttpResponse.json({ message }, { status: 500 });
     }
-
-    TEAM_DUMMY[teamIndex].teamName = teamName;
-    TEAM_DUMMY[teamIndex].content = content;
 
     return new HttpResponse(null, { status: 204 });
   }),
@@ -303,63 +303,64 @@ const teamServiceHandler = [
   // 팀원 추가 API
   http.post(`${API_URL}/team/:teamId/invitation`, async ({ request, params }) => {
     const accessToken = request.headers.get('Authorization');
-    const { teamId } = params;
-    const { userId, roleName } = (await request.json()) as TeamCoworkerForm;
+    const teamId = Number(params.teamId);
+    const { userId: coworkerId, roleName } = (await request.json()) as TeamCoworkerForm;
 
+    // 유저 인증 확인
     if (!accessToken) return new HttpResponse(null, { status: 401 });
 
-    const role = ROLE_DUMMY.find((role) => role.roleName === roleName);
+    // 유저 ID 정보 취득
+    const userId = convertTokenToUserId(accessToken);
+    if (!userId) return new HttpResponse(null, { status: 401 });
+
+    // 역할 정보 조회
+    const role = findRoleByRoleName(roleName);
     if (!role) return HttpResponse.json({ message: '유효하지 않은 역할입니다.' }, { status: 400 });
 
-    const existingUser = TEAM_USER_DUMMY.find(
-      (user) => user.teamId === Number(teamId) && user.userId === Number(userId),
-    );
-
+    // 팀 소속 여부 확인
+    const existingUser = findTeamUser(teamId, Number(coworkerId));
     if (existingUser) {
       return HttpResponse.json({ message: '이미 팀에 추가된 유저입니다.' }, { status: 404 });
     }
 
-    const newUser = {
-      teamId: Number(teamId),
-      userId: Number(userId),
+    // 팀원 추가
+    const newTeamUser = {
+      teamId,
+      userId: Number(coworkerId),
       roleId: role.roleId,
-      isPendingApproval: false,
+      isPendingApproval: true,
     };
+    createTeamUser(newTeamUser);
 
-    TEAM_USER_DUMMY.push(newUser);
-
-    return HttpResponse.json({ message: '팀원 추가 성공', user: newUser }, { status: 200 });
+    return HttpResponse.json(null, { status: 200 });
   }),
 
   // 팀원 삭제 API
   http.delete(`${API_URL}/team/:teamId/user/:userId`, ({ request, params }) => {
     const accessToken = request.headers.get('Authorization');
-    const { teamId, userId } = params;
+    const [teamId, coworkerId] = [params.teamId, params.userId].map(Number);
 
+    // 유저 인증 확인
     if (!accessToken) return new HttpResponse(null, { status: 401 });
 
-    const filteredTeamUsers = TEAM_USER_DUMMY.filter(
-      (teamUser) => !(teamUser.teamId === Number(teamId) && teamUser.userId === Number(userId)),
-    );
+    // 유저 ID 정보 취득
+    const userId = convertTokenToUserId(accessToken);
+    if (!userId) return new HttpResponse(null, { status: 401 });
 
-    if (TEAM_USER_DUMMY.length !== filteredTeamUsers.length) {
-      TEAM_USER_DUMMY.length = 0;
-      TEAM_USER_DUMMY.push(...filteredTeamUsers);
-    }
+    // 팀 소속 확인
+    const teamUser = findTeamUser(teamId, userId);
+    if (!teamUser) return new HttpResponse(null, { status: 403 });
 
-    const filteredProjectUsers = PROJECT_USER_DUMMY.filter((projectUser) => projectUser.userId !== Number(userId));
+    // 팀 내 권한 확인
+    const role = findRole(teamUser.roleId);
+    if (!role) return new HttpResponse(null, { status: 500 });
+    if (role.roleName !== 'HEAD') return new HttpResponse(null, { status: 403 });
 
-    if (PROJECT_USER_DUMMY.length !== filteredProjectUsers.length) {
-      PROJECT_USER_DUMMY.length = 0;
-      PROJECT_USER_DUMMY.push(...filteredProjectUsers);
-    }
+    // 팀원이 소속한 프로젝트 삭제
+    deleteAllProjectUserByTeamId(teamId, coworkerId);
 
-    const filteredTaskUsers = TASK_USER_DUMMY.filter((taskUser) => taskUser.userId !== Number(userId));
-
-    if (TASK_USER_DUMMY.length !== filteredTaskUsers.length) {
-      TASK_USER_DUMMY.length = 0;
-      TASK_USER_DUMMY.push(...filteredTaskUsers);
-    }
+    // 팀원 삭제
+    deleteTeamUser(teamId, coworkerId);
 
     return new HttpResponse(null, { status: 204 });
   }),
@@ -367,27 +368,38 @@ const teamServiceHandler = [
   // 팀원 권한 변경 API
   http.patch(`${API_URL}/team/:teamId/user/:userId/role`, async ({ request, params }) => {
     const accessToken = request.headers.get('Authorization');
-    const { teamId, userId } = params;
+    const [teamId, coworkerId] = [params.teamId, params.userId].map(Number);
     const { roleName } = (await request.json()) as TeamCoworkerForm;
 
-    if (!accessToken) {
-      return new HttpResponse(null, { status: 401 });
-    }
+    // 유저 인증 확인
+    if (!accessToken) return new HttpResponse(null, { status: 401 });
 
-    const role = ROLE_DUMMY.find((role) => role.roleName === roleName);
-    if (!role) {
+    // 유저 ID 정보 취득
+    const userId = convertTokenToUserId(accessToken);
+    if (!userId) return new HttpResponse(null, { status: 401 });
+
+    // 팀 소속 확인
+    const teamUser = findTeamUser(teamId, userId);
+    if (!teamUser) return new HttpResponse(null, { status: 403 });
+
+    // 팀내 권한 확인
+    const role = findRole(teamUser.roleId);
+    if (!role) return new HttpResponse(null, { status: 500 });
+    if (role.roleName !== 'HEAD') return new HttpResponse(null, { status: 403 });
+
+    // 요청 권한 확인
+    const coworkerRole = findRoleByRoleName(roleName);
+    if (!coworkerRole) {
       return HttpResponse.json({ message: '유효하지 않은 역할입니다.' }, { status: 400 });
     }
 
-    const teamUserIndex = TEAM_USER_DUMMY.findIndex(
-      (teamUser) => teamUser.teamId === Number(teamId) && teamUser.userId === Number(userId),
-    );
-
-    if (teamUserIndex === -1) {
-      return new HttpResponse(null, { status: 404 });
+    // 팀원 권한 변경
+    try {
+      updateTeamUser(teamId, coworkerId, coworkerRole.roleId);
+    } catch (error) {
+      const { message } = error as Error;
+      return HttpResponse.json({ message }, { status: 500 });
     }
-
-    TEAM_USER_DUMMY[teamUserIndex].roleId = role.roleId;
 
     return new HttpResponse(null, { status: 200 });
   }),

--- a/src/types/RoleType.tsx
+++ b/src/types/RoleType.tsx
@@ -12,6 +12,6 @@ export type RoleInfo = {
 
 export type Role = {
   roleId: number;
-  roleName: RoleName;
+  roleName: RoleName | null;
   roleType: 'TEAM' | 'PROJECT';
 };

--- a/src/types/TeamType.tsx
+++ b/src/types/TeamType.tsx
@@ -17,7 +17,7 @@ export type TeamInfoForm = Pick<Team, 'teamName' | 'content'>;
 
 export type TeamCoworkerForm = Omit<TeamCoworker, 'nickname'>;
 
-export type TeamForm = Omit<Team, 'teamId' | 'creatorId'> & { coworkers: TeamCoworkerForm[] };
+export type TeamForm = TeamInfoForm & { coworkers: TeamCoworkerForm[] };
 
 export type TeamListWithApproval = Omit<Team, 'creatorId'> &
   Pick<Role, 'roleName'> & {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] **\[Fix\]** 버그를 수정했어요.
- [x] **\[Refactor\]** 리팩토링을 했어요 (기능적인 변화 없이, api 변경 없이)

## Related Issues
- close #310 

## What does this PR do?
- [x] teamServiceHandler 리팩토링
- [x] mock 데이터 처리 로직을 재사용하기 위해 mockAPI  추가 작성
- [x] 팀 추방, 팀 탈퇴,  프로젝트원 추방 시 일정 수행자(`task_user`)는 남기도록 기능 수정
- [x] 팀 추방, 팀 탈퇴, 프로젝트원 추방 시 일정 수행자 목록 조회에 `roleName`을 null로 처리하도록 수정 

## Other information
1. 팀 소속 유저 검색 API에서 팀에 초대된 유저와 참여된 유저를 구별하지 않고, 모든 유저에 대하여 검색이 가능한 상태였습니다. 그래서 팀에 참여하고 있는 유저 내에서 검색이 진행되도록 필터를 추가했습니다.

2. 반복되는 로직을 mockUtils 파일로 분리하였습니다. (createTeamUserFormat, createProjectUserFormat)

3. 프로젝트 생성시 프로젝트원을 추가하는 과정에서 오류가 발생하면 일관성을 해칠 가능성이 있었습니다. 이를 데이터 무결성을 먼저 확인한 뒤 등록하도록 수정하여 일관성을 유지할 수 있도록 만들었습니다.

4. 데이터 타입중 유틸리티로 처리하던 데이터 구조가 이미 별칭으로 선언되어 있어, 이를 이용하도록 수정하였습니다.
