### PR TITLE
Fix: #326 기간 설정 UI (PeriodDateInput컴포넌트)에 시작일과 종료일 동기화 기능 문제 해결

### DIFF
--- a/src/components/common/PeriodDateInput.tsx
+++ b/src/components/common/PeriodDateInput.tsx
@@ -51,7 +51,7 @@ export default function PeriodDateInput({
   }, [startDateStr, endDateStr]);
 
   const handleDeadlineToggle = () => {
-    setValue(endDateFieldName, enableEndDateSync ? null : getValues(startDateFieldName));
+    setValue(endDateFieldName, enableEndDateSync ? getValues(startDateFieldName) : null);
     clearErrors(endDateFieldName);
     setHasDeadline((prev) => !prev);
   };

--- a/src/components/modal/project/ModalProjectForm.tsx
+++ b/src/components/modal/project/ModalProjectForm.tsx
@@ -157,7 +157,7 @@ export default function ModalProjectForm({ formId, onSubmit }: ModalProjectFormP
           endDateId="endDate"
           startDateFieldName="startDate"
           endDateFieldName="endDate"
-          enableEndDateSync
+          enableEndDateSync={false}
         />
 
         <SearchUserInput

--- a/src/components/modal/project/UpdateModalProject.tsx
+++ b/src/components/modal/project/UpdateModalProject.tsx
@@ -146,7 +146,7 @@ export default function UpdateModalProject({ projectId, onClose: handleClose }: 
               endDateId="endDate"
               startDateFieldName="startDate"
               endDateFieldName="endDate"
-              enableEndDateSync
+              enableEndDateSync={false}
             />
           </form>
         </FormProvider>

--- a/src/components/modal/task/UpdateModalTask.tsx
+++ b/src/components/modal/task/UpdateModalTask.tsx
@@ -176,7 +176,7 @@ export default function UpdateModalTask({
                   endDateFieldName="endDate"
                   limitStartDate={projectStartDate}
                   limitEndDate={projectEndDate}
-                  enableEndDateSync={false}
+                  enableEndDateSync
                 />
 
                 <MarkdownEditor id="content" label="내용" contentFieldName="content" />


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] **\[Fix\]** 버그를 수정했어요.

## Related Issues
- close #326 

## What does this PR do?
- [x] `enableEndDateSync` 처리 수정

## View
**`enableEndDateSync`를 활성화한 경우, 종료일이 시작일을 따라간다.**
![활성화 경우](https://github.com/user-attachments/assets/bb41e01b-1905-47e9-8f9d-334600f1bddb)

**`enableEndDateSync`를 비활성화한 경우, 종료일은 null이 되어 설정되지 않는다.**
![비활성화 경우](https://github.com/user-attachments/assets/fa77e4dd-a613-43d8-9350-fa56ee036e13)
