### PR TITLE
Fix: #329 동기화 기능 여부에 따라 시작일이 종료일보다 늦을 경우 처리 분기

### DIFF
--- a/src/components/common/PeriodDateInput.tsx
+++ b/src/components/common/PeriodDateInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { DateTime } from 'luxon';
 import { useFormContext } from 'react-hook-form';
 import { PERIOD_VALIDATION_RULES } from '@constants/formValidationRules';
@@ -43,6 +43,25 @@ export default function PeriodDateInput({
   const startDateStr = watch(startDateFieldName);
   const endDateStr = watch(endDateFieldName);
 
+  const handleStartDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const startDate = DateTime.fromISO(e.target.value).startOf('day');
+    const endDate = DateTime.fromISO(endDateStr).startOf('day');
+
+    const shouldUpdateEndDate = !hasDeadline || (endDate && startDate > endDate);
+    if (shouldUpdateEndDate) {
+      setValue(endDateFieldName, enableEndDateSync ? e.target.value : null);
+    }
+  };
+
+  const handleEndDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const startDate = DateTime.fromISO(startDateStr).startOf('day');
+    const endDate = DateTime.fromISO(e.target.value).startOf('day');
+    if (startDate > endDate) {
+      toastWarn('종료일은 시작일과 같거나 이후로 설정해주세요.');
+      setValue(endDateFieldName, enableEndDateSync ? startDateStr : null);
+    }
+  };
+
   useEffect(() => {
     const startDate = startDateStr ? DateTime.fromISO(startDateStr).startOf('day') : null;
     const endDate = endDateStr ? DateTime.fromISO(endDateStr).startOf('day') : null;
@@ -65,13 +84,7 @@ export default function PeriodDateInput({
           type="date"
           {...register(startDateFieldName, {
             ...PERIOD_VALIDATION_RULES.START_DATE(limitStartDate, limitEndDate),
-            onChange: (e) => {
-              const startDate = DateTime.fromISO(e.target.value).startOf('day');
-              const endDate = DateTime.fromISO(endDateStr).startOf('day');
-              if (startDate > endDate || !hasDeadline) {
-                setValue(endDateFieldName, enableEndDateSync ? e.target.value : null);
-              }
-            },
+            onChange: handleStartDateChange,
           })}
         />
         <div className={`my-5 h-10 grow text-xs text-error ${errors[startDateFieldName] ? 'visible' : 'invisible'}`}>
@@ -95,14 +108,7 @@ export default function PeriodDateInput({
               limitEndDate,
               hasDeadline ? startDateStr : null,
             ),
-            onChange: (e) => {
-              const startDate = DateTime.fromISO(startDateStr).startOf('day');
-              const endDate = DateTime.fromISO(e.target.value).startOf('day');
-              if (startDate > endDate) {
-                toastWarn('종료일은 시작일과 같거나 이후로 설정해주세요.');
-                setValue(endDateFieldName, enableEndDateSync ? startDateStr : null);
-              }
-            },
+            onChange: handleEndDateChange,
           })}
         />
         <div className={`my-5 h-10 grow text-xs text-error ${errors[endDateFieldName] ? 'visible' : 'invisible'}`}>

--- a/src/components/common/PeriodDateInput.tsx
+++ b/src/components/common/PeriodDateInput.tsx
@@ -46,7 +46,7 @@ export default function PeriodDateInput({
   useEffect(() => {
     const startDate = startDateStr ? DateTime.fromISO(startDateStr).startOf('day') : null;
     const endDate = endDateStr ? DateTime.fromISO(endDateStr).startOf('day') : null;
-
+    if (!endDate) setHasDeadline(false);
     if (startDate && endDate) setHasDeadline(startDate < endDate);
   }, [startDateStr, endDateStr]);
 
@@ -66,7 +66,11 @@ export default function PeriodDateInput({
           {...register(startDateFieldName, {
             ...PERIOD_VALIDATION_RULES.START_DATE(limitStartDate, limitEndDate),
             onChange: (e) => {
-              if (!hasDeadline) setValue(endDateFieldName, e.target.value);
+              const startDate = DateTime.fromISO(e.target.value).startOf('day');
+              const endDate = DateTime.fromISO(endDateStr).startOf('day');
+              if (startDate > endDate || !hasDeadline) {
+                setValue(endDateFieldName, enableEndDateSync ? e.target.value : null);
+              }
             },
           })}
         />
@@ -96,7 +100,7 @@ export default function PeriodDateInput({
               const endDate = DateTime.fromISO(e.target.value).startOf('day');
               if (startDate > endDate) {
                 toastWarn('종료일은 시작일과 같거나 이후로 설정해주세요.');
-                setValue(endDateFieldName, startDateStr);
+                setValue(endDateFieldName, enableEndDateSync ? startDateStr : null);
               }
             },
           })}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] **\[Fix\]** 버그를 수정했어요.

## Related Issues
- close #329 

## What does this PR do?
- [x] 동기화 기능 사용시, 시작일이 종료일보다 늦어지면 종료일이 null 이 설정되도록 수정
- [x] 동기화 기능 미사용시, 시작일이 종료일보다 늦어지면, 종료일이 시작일과 같아지도록 수정

## View
**동기화 기능 사용하는 경우: 일정 기간 설정**
![변경 후 시작일 변경시 종료일이 따라감](https://github.com/user-attachments/assets/c0732c70-77e3-4c10-a787-6497804f0675)

**동기화 기능 사용하지 않는 경우: 프로젝트 기간 설정**
![동기화 미설정시](https://github.com/user-attachments/assets/69dfa83b-ef36-487d-98eb-9ffece77c0b8)