### PR TITLE
Fix: #335 팀을 생성할 때 팀명만 등록하면, 팀 정보 모달창에서 데이터가 노출되지 않는 문제 해결

### DIFF
--- a/src/components/modal/team/UpdateModalTeam.tsx
+++ b/src/components/modal/team/UpdateModalTeam.tsx
@@ -66,10 +66,11 @@ export default function UpdateModalTeam({ teamId, onClose: handleClose }: Update
   } = methods;
 
   useEffect(() => {
-    if (teamInfo?.teamName && teamInfo?.content && teamCoworkers) {
-      reset({ teamName: teamInfo.teamName, content: teamInfo.content });
+    if (teamInfo) {
+      const { teamName, content } = teamInfo;
+      reset({ teamName, content });
     }
-  }, [teamInfo, teamCoworkers, reset]);
+  }, [teamInfo, reset]);
 
   const handleKeywordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setKeyword(e.target.value.trim());


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] **\[Fix\]** 버그를 수정했어요.

## Related Issues
- close #335 

## What does this PR do?
- [x] useEffect의 reset을 위한 조건문 수정