### PR TITLE
Feat: #262 팀 수정 및 삭제 권한 확인 기능 추가 및 권합 타입 재정리

### DIFF
--- a/src/components/common/AssigneeList.tsx
+++ b/src/components/common/AssigneeList.tsx
@@ -1,9 +1,10 @@
 import { IoMdCloseCircle } from 'react-icons/io';
 import RoleIcon from '@components/common/RoleIcon';
-import type { SearchUser, UserWithRole } from '@/types/UserType';
+import type { SearchUser } from '@/types/UserType';
+import type { ProjectCoworker } from '@/types/ProjectType';
 
 type AssigneeListProps = {
-  assigneeList: UserWithRole[];
+  assigneeList: ProjectCoworker[];
   onAssigneeDeleteClick: (user: SearchUser) => void;
 };
 

--- a/src/components/common/UserRoleSelectBox.tsx
+++ b/src/components/common/UserRoleSelectBox.tsx
@@ -2,19 +2,19 @@ import React from 'react';
 import { IoMdCloseCircle } from 'react-icons/io';
 import { PROJECT_ROLES, TEAM_CREATE_ROLES, TEAM_ROLES } from '@constants/role';
 import type { User } from '@/types/UserType';
-import type { RoleName } from '@/types/RoleType';
+import type { Roles } from '@/types/RoleType';
 
-type UserRoleSelectBoxProps<T extends RoleName> = {
+type UserRoleSelectBoxProps<T extends Roles> = {
   userId: User['userId'];
   nickname: User['nickname'];
   isHighlighted?: boolean;
-  defaultValue: RoleName;
+  defaultValue: Roles;
   roles: typeof TEAM_CREATE_ROLES | typeof TEAM_ROLES | typeof PROJECT_ROLES;
   onRoleChange: (userId: number, roleName: T) => void;
   onRemoveUser: (userId: number) => void;
 };
 
-export default function UserRoleSelectBox<T extends RoleName>({
+export default function UserRoleSelectBox<T extends Roles>({
   userId,
   nickname,
   isHighlighted = false,

--- a/src/components/modal/project/ModalProjectForm.tsx
+++ b/src/components/modal/project/ModalProjectForm.tsx
@@ -18,7 +18,7 @@ import { useParams } from 'react-router-dom';
 import type { SubmitHandler } from 'react-hook-form';
 import { getProjectNameList } from '@utils/extractDataList';
 import type { TeamSearchCallback } from '@/types/SearchCallbackType';
-import type { ProjectRoleName } from '@/types/RoleType';
+import type { ProjectRoles } from '@/types/RoleType';
 import type { ProjectCoworker, ProjectForm } from '@/types/ProjectType';
 import type { SearchUser, User } from '@/types/UserType';
 import type { Team } from '@/types/TeamType';
@@ -68,7 +68,7 @@ export default function ModalProjectForm({ formId, onSubmit }: ModalProjectFormP
     register,
   } = methods;
 
-  const handleRoleChange = (userId: User['userId'], roleName: ProjectRoleName) => {
+  const handleRoleChange = (userId: User['userId'], roleName: ProjectRoles) => {
     const updatedCoworkerInfos = coworkerInfos.map((coworkerInfo) =>
       coworkerInfo.userId === userId ? { ...coworkerInfo, roleName } : coworkerInfo,
     );

--- a/src/components/modal/project/UpdateModalProject.tsx
+++ b/src/components/modal/project/UpdateModalProject.tsx
@@ -30,7 +30,7 @@ import type { User } from '@/types/UserType';
 import type { Team } from '@/types/TeamType';
 import type { TeamSearchCallback } from '@/types/SearchCallbackType';
 import type { Project, ProjectForm, ProjectInfoForm } from '@/types/ProjectType';
-import type { ProjectRoleName } from '@/types/RoleType';
+import type { ProjectRoles } from '@/types/RoleType';
 
 type UpdateModalProjectProps = {
   projectId: Project['projectId'];
@@ -90,7 +90,7 @@ export default function UpdateModalProject({ projectId, onClose: handleClose }: 
     setKeyword(e.target.value.trim());
   };
 
-  const handleCoworkersClick = (userId: User['userId'], roleName: ProjectRoleName) => {
+  const handleCoworkersClick = (userId: User['userId'], roleName: ProjectRoles) => {
     const isIncludedUser = projectCoworkers.find((coworker) => coworker.userId === userId);
     if (isIncludedUser) return toastInfo('이미 포함된 프로젝트 멤버입니다');
 
@@ -99,7 +99,7 @@ export default function UpdateModalProject({ projectId, onClose: handleClose }: 
     clearData();
   };
 
-  const handleRoleChange = (userId: User['userId'], roleName: ProjectRoleName) => {
+  const handleRoleChange = (userId: User['userId'], roleName: ProjectRoles) => {
     updateProjectCoworkerRoleMutate({ userId, roleName });
   };
 
@@ -173,7 +173,7 @@ export default function UpdateModalProject({ projectId, onClose: handleClose }: 
                 userId={userId}
                 nickname={nickname}
                 roles={PROJECT_ROLES}
-                defaultValue={roleName as ProjectRoleName}
+                defaultValue={roleName as ProjectRoles}
                 onRoleChange={handleRoleChange}
                 onRemoveUser={handleRemoveUser}
               />

--- a/src/components/modal/task/ModalTaskForm.tsx
+++ b/src/components/modal/task/ModalTaskForm.tsx
@@ -23,8 +23,8 @@ import Validator from '@utils/Validator';
 import { getTaskNameList } from '@utils/extractDataList';
 
 import type { SubmitHandler } from 'react-hook-form';
-import type { SearchUser, UserWithRole } from '@/types/UserType';
-import type { Project } from '@/types/ProjectType';
+import type { SearchUser } from '@/types/UserType';
+import type { Project, ProjectCoworker } from '@/types/ProjectType';
 import type { CustomFile } from '@/types/FileType';
 import type { TaskForm } from '@/types/TaskType';
 import type { ProjectSearchCallback } from '@/types/SearchCallbackType';
@@ -40,7 +40,7 @@ export default function ModalTaskForm({ formId, project, onSubmit }: ModalTaskFo
   const { projectId, startDate: projectStartDate, endDate: projectEndDate } = project;
 
   const [keyword, setKeyword] = useState('');
-  const [assignees, setAssignees] = useState<UserWithRole[]>([]);
+  const [assignees, setAssignees] = useState<ProjectCoworker[]>([]);
   const [files, setFiles] = useState<CustomFile[]>([]);
 
   const { statusList, isStatusesLoading } = useReadStatuses(projectId);

--- a/src/components/modal/team/ModalTeamForm.tsx
+++ b/src/components/modal/team/ModalTeamForm.tsx
@@ -16,7 +16,7 @@ import { getTeamNameList } from '@utils/extractDataList';
 
 import type { SubmitHandler } from 'react-hook-form';
 import type { SearchUser, User } from '@/types/UserType';
-import type { TeamRoleName } from '@/types/RoleType';
+import type { TeamRoles } from '@/types/RoleType';
 import type { TeamCoworker, TeamForm } from '@/types/TeamType';
 import type { AllSearchCallback } from '@/types/SearchCallbackType';
 
@@ -57,7 +57,7 @@ export default function ModalTeamForm({ formId, onSubmit }: ModalTeamFormProps) 
     register,
   } = methods;
 
-  const handleRoleChange = (userId: User['userId'], roleName: TeamRoleName) => {
+  const handleRoleChange = (userId: User['userId'], roleName: TeamRoles) => {
     const updatedCoworkerInfos = coworkerInfos.map((coworkerInfo) =>
       coworkerInfo.userId === userId ? { ...coworkerInfo, roleName } : coworkerInfo,
     );

--- a/src/components/modal/team/UpdateModalTeam.tsx
+++ b/src/components/modal/team/UpdateModalTeam.tsx
@@ -9,7 +9,8 @@ import {
   useUpdateTeamCoworkerRole,
   useUpdateTeamInfo,
 } from '@hooks/query/useTeamQuery';
-import { TEAM_DEFAULT_ROLE, TEAM_ROLES } from '@constants/role';
+import useStore from '@stores/useStore';
+import { TEAM_DEFAULT_ROLE, TEAM_ROLES, TEAM_ROLES_PRIORITY } from '@constants/role';
 import { TEAM_VALIDATION_RULES } from '@constants/formValidationRules';
 import ModalLayout from '@layouts/ModalLayout';
 import Spinner from '@components/common/Spinner';
@@ -19,15 +20,16 @@ import SearchUserInput from '@components/common/SearchUserInput';
 import UserRoleSelectBox from '@components/common/UserRoleSelectBox';
 import DescriptionTextarea from '@components/common/DescriptionTextarea';
 import DuplicationCheckInput from '@components/common/DuplicationCheckInput';
+import hasPermission from '@utils/permissionChecker';
 import { getTeamNameList } from '@utils/extractDataList';
 import { findUser } from '@services/userService';
 import useAxios from '@hooks/useAxios';
 import useToast from '@hooks/useToast';
 
+import type { User } from '@/types/UserType';
 import type { Team, TeamForm } from '@/types/TeamType';
 import type { TeamRoles } from '@/types/RoleType';
 import type { AllSearchCallback } from '@/types/SearchCallbackType';
-import type { User } from '@/types/UserType';
 
 type UpdateModalTeamProps = {
   teamId: Team['teamId'];
@@ -37,12 +39,16 @@ type UpdateModalTeamProps = {
 export default function UpdateModalTeam({ teamId, onClose: handleClose }: UpdateModalTeamProps) {
   const updateTeamFormId = 'updateTeamForm';
   const [keyword, setKeyword] = useState('');
-  const { toastInfo } = useToast();
+  const { toastInfo, toastWarn } = useToast();
+  const {
+    userInfo: { userId },
+  } = useStore();
 
   const { teamCoworkers, isLoading: isTeamCoworkersLoading } = useReadTeamCoworkers(teamId);
   const { teamList, isLoading: isTeamListLoading } = useReadTeams();
   const { teamInfo } = useReadTeamInfo(Number(teamId));
   const teamNameList = useMemo(() => getTeamNameList(teamList, teamInfo?.teamName), [teamList, teamInfo?.teamName]);
+  const teamUser = teamCoworkers.find((coworker) => coworker.userId === userId);
 
   const { mutate: updateTeamMutate } = useUpdateTeamInfo();
   const { mutate: addTeamCoworkerMutate } = useAddTeamCoworker(teamId);
@@ -77,11 +83,20 @@ export default function UpdateModalTeam({ teamId, onClose: handleClose }: Update
   };
 
   const handleFormSubmit: SubmitHandler<TeamForm> = async (formData) => {
+    if (!teamUser) return toastWarn('유저 권한을 확인할 수 없습니다.');
+    if (!hasPermission<TeamRoles>(TEAM_ROLES_PRIORITY, 'HEAD', teamUser.roleName)) {
+      return toastWarn('팀 수정 권한이 없습니다.');
+    }
     updateTeamMutate({ teamId, teamInfo: formData });
     handleClose();
   };
 
   const handleCoworkersClick = (userId: User['userId'], roleName: TeamRoles) => {
+    if (!teamUser) return toastWarn('유저 권한을 확인할 수 없습니다.');
+    if (!hasPermission<TeamRoles>(TEAM_ROLES_PRIORITY, 'HEAD', teamUser.roleName)) {
+      return toastWarn('팀원 추가 권한이 없습니다.');
+    }
+
     const isIncludedUser = teamCoworkers.find((coworker) => coworker.userId === userId);
     if (isIncludedUser) return toastInfo('이미 포함된 팀원입니다');
 
@@ -91,10 +106,18 @@ export default function UpdateModalTeam({ teamId, onClose: handleClose }: Update
   };
 
   const handleRemoveUser = (userId: User['userId']) => {
+    if (!teamUser) return toastWarn('유저 권한을 확인할 수 없습니다.');
+    if (!hasPermission<TeamRoles>(TEAM_ROLES_PRIORITY, 'HEAD', teamUser.roleName)) {
+      return toastWarn('팀원 삭제 권한이 없습니다.');
+    }
     deleteCoworkerMutate(userId);
   };
 
   const handleRoleChange = (userId: User['userId'], roleName: TeamRoles) => {
+    if (!teamUser) return toastWarn('유저 권한을 확인할 수 없습니다.');
+    if (!hasPermission<TeamRoles>(TEAM_ROLES_PRIORITY, 'HEAD', teamUser.roleName)) {
+      return toastWarn('팀원 역할 권한이 없습니다.');
+    }
     updateTeamCoworkerRoleMutate({ userId, roleName });
   };
 

--- a/src/components/modal/team/UpdateModalTeam.tsx
+++ b/src/components/modal/team/UpdateModalTeam.tsx
@@ -25,7 +25,7 @@ import useAxios from '@hooks/useAxios';
 import useToast from '@hooks/useToast';
 
 import type { Team, TeamForm } from '@/types/TeamType';
-import type { TeamRoleName } from '@/types/RoleType';
+import type { TeamRoles } from '@/types/RoleType';
 import type { AllSearchCallback } from '@/types/SearchCallbackType';
 import type { User } from '@/types/UserType';
 
@@ -81,7 +81,7 @@ export default function UpdateModalTeam({ teamId, onClose: handleClose }: Update
     handleClose();
   };
 
-  const handleCoworkersClick = (userId: User['userId'], roleName: TeamRoleName) => {
+  const handleCoworkersClick = (userId: User['userId'], roleName: TeamRoles) => {
     const isIncludedUser = teamCoworkers.find((coworker) => coworker.userId === userId);
     if (isIncludedUser) return toastInfo('이미 포함된 팀원입니다');
 
@@ -94,7 +94,7 @@ export default function UpdateModalTeam({ teamId, onClose: handleClose }: Update
     deleteCoworkerMutate(userId);
   };
 
-  const handleRoleChange = (userId: User['userId'], roleName: TeamRoleName) => {
+  const handleRoleChange = (userId: User['userId'], roleName: TeamRoles) => {
     updateTeamCoworkerRoleMutate({ userId, roleName });
   };
 
@@ -150,7 +150,7 @@ export default function UpdateModalTeam({ teamId, onClose: handleClose }: Update
                 nickname={nickname}
                 roles={TEAM_ROLES}
                 isHighlighted={!isPendingApproval}
-                defaultValue={roleName as TeamRoleName}
+                defaultValue={roleName as TeamRoles}
                 onRoleChange={handleRoleChange}
                 onRemoveUser={handleRemoveUser}
               />

--- a/src/components/project/ProjectItem.tsx
+++ b/src/components/project/ProjectItem.tsx
@@ -5,10 +5,13 @@ import useModal from '@hooks/useModal';
 import useToast from '@hooks/useToast';
 import { useDeleteProject, useReadProjectCoworkers } from '@hooks/query/useProjectQuery';
 import useStore from '@stores/useStore';
+import hasPermission from '@utils/permissionChecker';
+import { PROJECT_ROLES_PRIORITY } from '@constants/role';
 import UpdateModalProject from '@components/modal/project/UpdateModalProject';
 
 import type { Team } from '@/types/TeamType';
 import type { Project } from '@/types/ProjectType';
+import type { ProjectRoles } from '@/types/RoleType';
 
 type ProjectItemProps = {
   teamId: Team['teamId'];
@@ -25,15 +28,21 @@ export default function ProjectItem({ teamId, project }: ProjectItemProps) {
   const { projectCoworkers } = useReadProjectCoworkers(project.projectId);
   const { mutate: deleteProjectMutate } = useDeleteProject(teamId);
 
-  const userProjectRole = projectCoworkers.find((coworker) => coworker.userId === userId)?.roleName;
+  const projectUser = projectCoworkers.find((coworker) => coworker.userId === userId);
 
   const handleOpenUpdateModal = () => {
-    if (userProjectRole !== 'ADMIN') return toastWarn('프로젝트 수정 권한이 없습니다.');
+    if (!projectUser) return toastWarn('참여 중인 프로젝트가 아닙니다.');
+    if (!hasPermission<ProjectRoles>(PROJECT_ROLES_PRIORITY, 'ADMIN', projectUser.roleName)) {
+      return toastWarn('프로젝트 수정 권한이 없습니다.');
+    }
     openUpdateModal();
   };
 
   const handleDeleteClick = (projectId: Project['projectId']) => {
-    if (userProjectRole !== 'ADMIN') return toastWarn('프로젝트 삭제 권한이 없습니다.');
+    if (!projectUser) return toastWarn('참여 중인 프로젝트가 아닙니다.');
+    if (!hasPermission<ProjectRoles>(PROJECT_ROLES_PRIORITY, 'ADMIN', projectUser.roleName)) {
+      return toastWarn('프로젝트 삭제 권한이 없습니다.');
+    }
     deleteProjectMutate(projectId);
   };
 

--- a/src/components/sidebar/ListTeam.tsx
+++ b/src/components/sidebar/ListTeam.tsx
@@ -33,7 +33,7 @@ export default function ListTeam({ data, targetId }: ListTeamProps) {
                 <span>{team.teamName}</span>
               </Link>
               <button
-                className="mr-6 flex items-center text-main hover:brightness-50"
+                className="mr-6 flex items-center text-main hover:brightness-50 focus-visible:outline-none"
                 type="button"
                 onClick={(e) => {
                   e.preventDefault();

--- a/src/constants/role.ts
+++ b/src/constants/role.ts
@@ -1,9 +1,20 @@
-import { deepFreeze } from '@utils/deepFreeze';
-import type { RoleInfo } from '@/types/RoleType';
+import type { ProjectRoles, RoleInfo, TeamRoles } from '@/types/RoleType';
 
-export const TEAM_ROLES = deepFreeze(['HEAD', 'LEADER', 'MATE'] as const);
-export const TEAM_CREATE_ROLES = deepFreeze(['LEADER', 'MATE'] as const);
-export const PROJECT_ROLES = deepFreeze(['ADMIN', 'LEADER', 'ASSIGNEE'] as const);
+export const TEAM_ROLES_PRIORITY = {
+  HEAD: 3,
+  LEADER: 2,
+  MATE: 1,
+};
+
+export const PROJECT_ROLES_PRIORITY = {
+  ADMIN: 3,
+  LEADER: 2,
+  ASSIGNEE: 1,
+};
+
+export const TEAM_ROLES = Object.keys(TEAM_ROLES_PRIORITY) as TeamRoles[];
+export const TEAM_CREATE_ROLES = TEAM_ROLES.filter((role) => role !== 'HEAD');
+export const PROJECT_ROLES = Object.keys(PROJECT_ROLES_PRIORITY) as ProjectRoles[];
 
 export const PROJECT_DEFAULT_ROLE = 'ASSIGNEE';
 export const TEAM_DEFAULT_ROLE = 'MATE';

--- a/src/hooks/useProjectContext.tsx
+++ b/src/hooks/useProjectContext.tsx
@@ -1,8 +1,7 @@
 import { useOutletContext } from 'react-router-dom';
-import { Project } from '@/types/ProjectType';
-import { UserWithRole } from '@/types/UserType';
+import { Project, ProjectCoworker } from '@/types/ProjectType';
 
-export type ProjectContext = { project: Project; projectCoworkers: UserWithRole[] };
+export type ProjectContext = { project: Project; projectCoworkers: ProjectCoworker[] };
 
 export default function useProjectContext() {
   return useOutletContext<ProjectContext>();

--- a/src/layouts/page/ProjectLayout.tsx
+++ b/src/layouts/page/ProjectLayout.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 import { Navigate, NavLink, Outlet, useParams } from 'react-router-dom';
 import { RiSettings5Fill } from 'react-icons/ri';
+import { PROJECT_ROLES_PRIORITY } from '@constants/role';
+import hasPermission from '@utils/permissionChecker';
 import useStore from '@stores/useStore';
 import useModal from '@hooks/useModal';
 import useToast from '@hooks/useToast';
@@ -14,6 +16,7 @@ import ListProject from '@components/sidebar/ListProject';
 import CreateModalTask from '@components/modal/task/CreateModalTask';
 import UpdateModalProject from '@components/modal/project/UpdateModalProject';
 import CreateModalProjectStatus from '@components/modal/project-status/CreateModalProjectStatus';
+import type { ProjectRoles } from '@/types/RoleType';
 
 export default function ProjectLayout() {
   const { teamId, projectId } = useParams();
@@ -32,7 +35,7 @@ export default function ProjectLayout() {
     () => projectList?.find((project) => project.projectId === Number(projectId)),
     [projectList, projectId],
   );
-  const userProjectRole = projectCoworkers.find((coworker) => coworker.userId === userInfo.userId)?.roleName;
+  const projectUser = projectCoworkers.find((coworker) => coworker.userId === userInfo.userId);
 
   if (isProjectLoading || isProjectCoworkersLoading || isStatusesLoading) return <Spinner />;
   if (!teamInfo) return <Navigate to="/error" replace />;
@@ -47,7 +50,8 @@ export default function ProjectLayout() {
 
   // ToDo: 권한 확인하는 로직을 한 곳으로 모은 hook을 만들 것.
   const handleUpdateProjectClick = () => {
-    if (userProjectRole !== 'ADMIN') {
+    if (!projectUser) return toastWarn('유저 권한을 확인할 수 없습니다.');
+    if (!hasPermission<ProjectRoles>(PROJECT_ROLES_PRIORITY, 'ADMIN', projectUser.roleName)) {
       return toastWarn('프로젝트 수정 권한이 없습니다.');
     }
     openProjectModal();

--- a/src/pages/setting/TeamJoinedPage.tsx
+++ b/src/pages/setting/TeamJoinedPage.tsx
@@ -1,13 +1,45 @@
+import { useQueryClient } from '@tanstack/react-query';
 import Meta from '@components/common/Meta';
 import Spinner from '@components/common/Spinner';
+import useToast from '@hooks/useToast';
 import { useDeleteTeam, useLeaveTeam, useReadTeams } from '@hooks/query/useTeamQuery';
 import { useStore } from '@stores/useStore';
+import { TEAM_ROLES_PRIORITY } from '@constants/role';
+import hasPermission from '@utils/permissionChecker';
+import { generateTeamCoworkersQueryKey } from '@utils/queryKeyGenerator';
+import { findTeamCoworker } from '@services/teamService';
+
+import type { Team } from '@/types/TeamType';
+import type { TeamRoles } from '@/types/RoleType';
 
 export default function JoinedTeamPage() {
   const { joinedTeamList, isLoading } = useReadTeams();
   const { mutate: leaveTeam } = useLeaveTeam();
   const { mutate: deleteTeam } = useDeleteTeam();
-  const { userInfo } = useStore();
+  const {
+    userInfo: { userId },
+  } = useStore();
+  const { toastWarn } = useToast();
+
+  const queryClient = useQueryClient();
+
+  const handleDeleteClick = async (teamId: Team['teamId']) => {
+    const teamCoworkers = await queryClient.ensureQueryData({
+      queryKey: generateTeamCoworkersQueryKey(teamId),
+      queryFn: async () => {
+        const { data } = await findTeamCoworker(teamId);
+        return data;
+      },
+    });
+    const teamUser = teamCoworkers.find((coworker) => coworker.userId === userId);
+
+    if (!teamUser) return toastWarn('유저 권한을 확인할 수 없습니다.');
+    if (!hasPermission<TeamRoles>(TEAM_ROLES_PRIORITY, 'HEAD', teamUser.roleName)) {
+      return toastWarn('팀 삭제 권한이 없습니다.');
+    }
+    deleteTeam(teamId);
+  };
+
   if (isLoading) return <Spinner />;
 
   return (
@@ -34,11 +66,11 @@ export default function JoinedTeamPage() {
                 </div>
 
                 <div className="mx-4 flex w-45 shrink-0 flex-col gap-4">
-                  {team.creatorId === userInfo.userId && (
+                  {team.creatorId === userId && (
                     <button
                       type="button"
                       className="rounded-md bg-red-500 px-5 py-2 text-sm text-white hover:brightness-90"
-                      onClick={() => deleteTeam(team.teamId)}
+                      onClick={() => handleDeleteClick(team.teamId)}
                     >
                       삭제하기
                     </button>

--- a/src/pages/team/TeamPage.tsx
+++ b/src/pages/team/TeamPage.tsx
@@ -1,14 +1,17 @@
 import { useParams } from 'react-router-dom';
-import CreateModalProject from '@components/modal/project/CreateModalProject';
+import { TEAM_ROLES_PRIORITY } from '@constants/role';
 import { useStore } from '@stores/useStore';
 import useModal from '@hooks/useModal';
 import useToast from '@hooks/useToast';
-import Meta from '@components/common/Meta';
 import { useReadProjects } from '@hooks/query/useProjectQuery';
 import { useReadTeamCoworkers, useReadTeams } from '@hooks/query/useTeamQuery';
+import hasPermission from '@utils/permissionChecker';
+import Meta from '@components/common/Meta';
 import Spinner from '@components/common/Spinner';
 import ProjectItemList from '@components/project/ProjectItemList';
 import EmptyProjectItemList from '@components/project/EmptyProjectItemList';
+import CreateModalProject from '@components/modal/project/CreateModalProject';
+import type { TeamRoles } from '@/types/RoleType';
 
 export default function TeamPage() {
   const { showModal: showProjectModal, openModal: openProjectModal, closeModal: closeProjectModal } = useModal();
@@ -23,13 +26,14 @@ export default function TeamPage() {
   const { teamCoworkers } = useReadTeamCoworkers(Number(teamId));
 
   const team = joinedTeamList.find((team) => team.teamId.toString() === teamId);
-  const userTeamRole = teamCoworkers.find((coworker) => coworker.userId === userId)?.roleName || null;
+  const teamUser = teamCoworkers.find((coworker) => coworker.userId === userId);
   const teamName = team ? team.teamName : '';
 
   const handleCreateProjectClick = () => {
     if (!teamId) return toastWarn('팀을 선택한 후 프로젝트 생성을 진행해주세요.');
 
-    if (userTeamRole !== 'HEAD' && userTeamRole !== 'LEADER') {
+    if (!teamUser) return toastWarn('유저 권한을 확인할 수 없습니다.');
+    if (!hasPermission<TeamRoles>(TEAM_ROLES_PRIORITY, 'LEADER', teamUser.roleName)) {
       return toastWarn('프로젝트 생성 권한이 없습니다.');
     }
 
@@ -53,7 +57,7 @@ export default function TeamPage() {
             type="button"
             onClick={handleCreateProjectClick}
             aria-label="새 프로젝트 생성"
-            className="mr-10 font-bold text-main hover:brightness-50"
+            className="mr-10 font-bold text-main hover:brightness-50 focus-visible:outline-none"
           >
             + 프로젝트 생성
           </button>

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -4,7 +4,7 @@ import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 import type { Team } from '@/types/TeamType';
 import type { Project, ProjectForm, ProjectInfoForm } from '@/types/ProjectType';
 import type { User, SearchUser, UserWithRole } from '@/types/UserType';
-import type { ProjectRoleName } from '@/types/RoleType';
+import type { ProjectRoles } from '@/types/RoleType';
 
 /**
  * 프로젝트에 속한 유저 목록을 검색하는 API
@@ -65,8 +65,8 @@ export async function getProjectUserRoleList(projectId: Project['projectId'], ax
  *
  * @export
  * @async
- * @param {Team['teamId']} teamId - 팀 ID
- * @param {ProjectForm} projectData - 프로젝트 생성 정보 객체
+ * @param {Team['teamId']} teamId               - 팀 ID
+ * @param {ProjectForm} projectData             - 프로젝트 생성 정보 객체
  * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
  * @returns {Promise<AxiosResponse<void>>}
  */
@@ -96,9 +96,9 @@ export async function deleteProject(projectId: Project['projectId'], axiosConfig
  *
  * @export
  * @async
- * @param {number} teamId - 팀 ID
- * @param {number} projectId - 수정할 프로젝트 ID
- * @param {ProjectInfoForm} formData - 수정할 프로젝트 정보 객체
+ * @param {number} teamId                       - 팀 ID
+ * @param {number} projectId                    - 수정할 프로젝트 ID
+ * @param {ProjectInfoForm} formData            - 수정할 프로젝트 정보 객체
  * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
  * @returns {Promise<AxiosResponse<void>>}
  */
@@ -118,14 +118,14 @@ export async function updateProjectInfo(
  * @async
  * @param {Project['projectId']} projectId      - 프로젝트 ID
  * @param {User['userId']} userId               - 초대할 유저 ID
- * @param {ProjectRoleName} roleName   - 유저의 역할
+ * @param {ProjectRoles} roleName               - 유저의 역할
  * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
  * @returns {Promise<AxiosResponse<void>>}
  */
 export async function addProjectCoworker(
   projectId: Project['projectId'],
   userId: User['userId'],
-  roleName: ProjectRoleName,
+  roleName: ProjectRoles,
   axiosConfig: AxiosRequestConfig = {},
 ): Promise<AxiosResponse<void>> {
   return authAxios.post(`/project/${projectId}/user`, { userId, roleName }, axiosConfig);
@@ -138,14 +138,14 @@ export async function addProjectCoworker(
  * @async
  * @param {Project['projectId']} projectId      - 프로젝트 ID
  * @param {User['userId']} userId               - 유저 ID
- * @param {ProjectRoleName} roleName   - 업데이트할 역할
+ * @param {ProjectRoles} roleName               - 업데이트할 역할
  * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
  * @returns {Promise<AxiosResponse<void>>}
  */
 export async function updateProjectRole(
   projectId: Project['projectId'],
   userId: User['userId'],
-  roleName: ProjectRoleName,
+  roleName: ProjectRoles,
   axiosConfig: AxiosRequestConfig = {},
 ): Promise<AxiosResponse<void>> {
   return authAxios.patch(`/project/${projectId}/user/${userId}/role`, { roleName }, axiosConfig);

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -2,8 +2,8 @@ import { authAxios } from '@services/axiosProvider';
 
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 import type { Team } from '@/types/TeamType';
-import type { Project, ProjectForm, ProjectInfoForm } from '@/types/ProjectType';
-import type { User, SearchUser, UserWithRole } from '@/types/UserType';
+import type { Project, ProjectCoworker, ProjectForm, ProjectInfoForm } from '@/types/ProjectType';
+import type { User, SearchUser } from '@/types/UserType';
 import type { ProjectRoles } from '@/types/RoleType';
 
 /**
@@ -54,10 +54,10 @@ export async function getProjectList(teamId: Team['teamId'], axiosConfig: AxiosR
  * @async
  * @param {Project['projectId']} projectId      - 프로젝트 ID
  * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
- * @returns {Promise<AxiosResponse<UserWithRole[]>>}
+ * @returns {Promise<AxiosResponse<ProjectCoworker[]>>}
  */
 export async function getProjectUserRoleList(projectId: Project['projectId'], axiosConfig: AxiosRequestConfig = {}) {
-  return authAxios.get<UserWithRole[]>(`/project/${projectId}/user`, axiosConfig);
+  return authAxios.get<ProjectCoworker[]>(`/project/${projectId}/user`, axiosConfig);
 }
 
 /**

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -2,8 +2,8 @@ import { authAxios } from '@services/axiosProvider';
 
 import type { AxiosRequestConfig } from 'axios';
 import type { TaskFile } from '@/types/FileType';
-import type { Project } from '@/types/ProjectType';
-import type { User, UserWithRole } from '@/types/UserType';
+import type { Project, ProjectCoworker } from '@/types/ProjectType';
+import type { User } from '@/types/UserType';
 import type { Task, TaskCreationForm, TaskUpdateForm, TaskListWithStatus, TaskOrderForm } from '@/types/TaskType';
 
 /**
@@ -84,14 +84,14 @@ export async function updateTaskOrder(
  * @param {Project['projectId']} projectId      - 프로젝트 ID
  * @param {Task['taskId']} taskId               - 일정 ID
  * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
- * @returns {Promise<AxiosResponse<UserWithRole[]>>}
+ * @returns {Promise<AxiosResponse<ProjectCoworker[]>>}
  */
 export async function findAssignees(
   projectId: Project['projectId'],
   taskId: Task['taskId'],
   axiosConfig: AxiosRequestConfig = {},
 ) {
-  return authAxios.get<UserWithRole[]>(`/project/${projectId}/task/${taskId}/assignee`, axiosConfig);
+  return authAxios.get<ProjectCoworker[]>(`/project/${projectId}/task/${taskId}/assignee`, axiosConfig);
 }
 
 /**

--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -2,7 +2,7 @@ import { authAxios } from '@services/axiosProvider';
 import type { AxiosRequestConfig } from 'axios';
 import type { SearchUser, User } from '@/types/UserType';
 import type { Team, TeamCoworker, TeamForm, TeamInfoForm } from '@/types/TeamType';
-import type { TeamRoleName } from '@/types/RoleType';
+import type { TeamRoles } from '@/types/RoleType';
 
 /**
  * 팀에 속한 유저 목록을 검색하는 API
@@ -101,7 +101,7 @@ export async function declineTeamInvitation(teamId: Team['teamId'], axiosConfig:
 export async function addTeamMember(
   teamId: Team['teamId'],
   userId: User['userId'],
-  roleName: TeamRoleName,
+  roleName: TeamRoles,
   axiosConfig: AxiosRequestConfig = {},
 ) {
   return authAxios.post(`/team/${teamId}/invitation`, { userId, roleName }, axiosConfig);
@@ -132,14 +132,14 @@ export async function removeTeamMember(
  * @async
  * @param {Team['teamId']} teamId               - 팀 ID
  * @param {User['userId']} userId               - 유저 ID
- * @param {TeamRoleName} roleName               - 역할 이름름
+ * @param {TeamRoles} roleName                  - 역할 이름
  * @param {AxiosRequestConfig} [axiosConfig={}] - axios 요청 옵션 설정 객체
  * @returns {Promise<AxiosResponse<void>>}
  */
 export async function updateTeamRole(
   teamId: Team['teamId'],
   userId: User['userId'],
-  roleName: TeamRoleName,
+  roleName: TeamRoles,
   axiosConfig: AxiosRequestConfig = {},
 ) {
   return authAxios.patch(`/team/${teamId}/user/${userId}/role`, { roleName }, axiosConfig);

--- a/src/types/ProjectType.tsx
+++ b/src/types/ProjectType.tsx
@@ -1,5 +1,5 @@
 import type { User } from '@/types/UserType';
-import type { ProjectRoleName } from '@/types/RoleType';
+import type { ProjectRoles } from '@/types/RoleType';
 
 // ToDo: API 설계 완료시 데이터 타입 변경할 것
 export type Project = {
@@ -13,7 +13,7 @@ export type Project = {
 
 export type ProjectCoworker = {
   userId: User['userId'];
-  roleName: ProjectRoleName;
+  roleName: ProjectRoles;
   nickname: string;
 };
 

--- a/src/types/RoleType.tsx
+++ b/src/types/RoleType.tsx
@@ -1,9 +1,7 @@
 import { PROJECT_ROLES_PRIORITY, TEAM_ROLES_PRIORITY } from '@constants/role';
 
 export type RolePriorityMap = Record<string, number>;
-export type RolePriority<T extends TeamRoles | ProjectRoles> = T extends TeamRoles
-  ? TeamRolesPriority
-  : ProjectRolesPriority;
+export type RolePriority<T extends Roles> = [T] extends [TeamRoles] ? TeamRolesPriority : ProjectRolesPriority;
 
 export type TeamRolesPriority = typeof TEAM_ROLES_PRIORITY;
 export type ProjectRolesPriority = typeof PROJECT_ROLES_PRIORITY;
@@ -21,6 +19,6 @@ export type RoleInfo = {
 
 export type Role = {
   roleId: number;
-  roleName: Roles | null;
+  roleName: Roles;
   roleType: 'TEAM' | 'PROJECT';
 };

--- a/src/types/RoleType.tsx
+++ b/src/types/RoleType.tsx
@@ -19,6 +19,6 @@ export type RoleInfo = {
 
 export type Role = {
   roleId: number;
-  roleName: Roles;
+  roleName: Roles | null;
   roleType: 'TEAM' | 'PROJECT';
 };

--- a/src/types/RoleType.tsx
+++ b/src/types/RoleType.tsx
@@ -1,17 +1,26 @@
-export type TeamRoleName = 'HEAD' | 'LEADER' | 'MATE';
+import { PROJECT_ROLES_PRIORITY, TEAM_ROLES_PRIORITY } from '@constants/role';
 
-export type ProjectRoleName = 'ADMIN' | 'LEADER' | 'ASSIGNEE';
+export type RolePriorityMap = Record<string, number>;
+export type RolePriority<T extends TeamRoles | ProjectRoles> = T extends TeamRoles
+  ? TeamRolesPriority
+  : ProjectRolesPriority;
 
-export type RoleName = TeamRoleName | ProjectRoleName;
+export type TeamRolesPriority = typeof TEAM_ROLES_PRIORITY;
+export type ProjectRolesPriority = typeof PROJECT_ROLES_PRIORITY;
+
+export type TeamRoles = keyof TeamRolesPriority;
+export type ProjectRoles = keyof ProjectRolesPriority;
+
+export type Roles = TeamRoles | ProjectRoles;
 
 export type RoleInfo = {
-  roleName: RoleName;
+  roleName: Roles;
   label: string;
   description: string;
 };
 
 export type Role = {
   roleId: number;
-  roleName: RoleName | null;
+  roleName: Roles | null;
   roleType: 'TEAM' | 'PROJECT';
 };

--- a/src/types/TeamType.tsx
+++ b/src/types/TeamType.tsx
@@ -1,5 +1,5 @@
 import type { User } from '@/types/UserType';
-import type { Role, TeamRoleName } from '@/types/RoleType';
+import type { Role, TeamRoles } from '@/types/RoleType';
 
 export type Team = {
   teamId: number;
@@ -10,7 +10,7 @@ export type Team = {
 
 export type TeamCoworker = {
   userId: User['userId'];
-  roleName: TeamRoleName;
+  roleName: TeamRoles;
   nickname: string;
   isPendingApproval: boolean;
 };

--- a/src/utils/permissionChecker.ts
+++ b/src/utils/permissionChecker.ts
@@ -1,0 +1,9 @@
+import { ProjectRoles, RolePriority, TeamRoles } from '@/types/RoleType';
+
+export default function hasPermission<T extends TeamRoles | ProjectRoles>(
+  rolePriorityMap: RolePriority<T>,
+  requiredRole: keyof RolePriority<T>,
+  userRole: keyof RolePriority<T>,
+): boolean {
+  return rolePriorityMap[userRole] >= rolePriorityMap[requiredRole];
+}

--- a/src/utils/permissionChecker.ts
+++ b/src/utils/permissionChecker.ts
@@ -1,6 +1,6 @@
-import { ProjectRoles, RolePriority, TeamRoles } from '@/types/RoleType';
+import type { RolePriority, Roles } from '@/types/RoleType';
 
-export default function hasPermission<T extends TeamRoles | ProjectRoles>(
+export default function hasPermission<T extends Roles>(
   rolePriorityMap: RolePriority<T>,
   requiredRole: keyof RolePriority<T>,
   userRole: keyof RolePriority<T>,


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] **\[Feat\]** 새로운 기능을 추가했어요.
- [x] **\[Refactor\]** 리팩토링을 했어요 (기능적인 변화 없이, api 변경 없이)

## Related Issues
- close #262 

## What does this PR do?
- [x] 권한 타입 추가 및 정리
- [x] 권한 확인 유틸리티 함수 정의 (hasPermission)
- [x] 기존 권한 확인 로직 수정
- [x] 팀 삭제 권한 확인 기능 추가
- [x] 팀 수정 권한 확인 기능 추가
- [x] 팀 역할 권한 확인 기능 추가
- [x] 팀원 추가 권한 확인 기능 추가

## Other information
1. 권한 확인 로직 중 일부가 반복되는 경향이 있어 다음 PR에서 리팩토링을 해볼 예정입니다.
2. 권한 확인 기능을 위한 추가 권한 타입을 정의하였습니다. 추가적으로 기존의 타입들도 literal value로 직접적으로 작성되어 있던 부분을 추가/수정됨에 따라 자동으로 확장되도록 수정했습니다.
3. 기존 타입 변경에 따라 많은 파일이 변경되었습니다. 중점적으로 확인해야할 파일은 다음과 같습니다.
- 기능 추가를 위해 추가/수정한 파일 : `types/RoleType.tsx`, `constants/role.ts`, `utils/permissionChecker.ts`
- 권한 확인 로직을 추가한 파일 :  `UpdateModalTeam.tsx`, `ProjectIrem.tsx`, `ProjectLayout.tsx`, `TeamJoinedPage.tsx`, `TeamPage.tsx`

## View
![동작](https://github.com/user-attachments/assets/e33a6ede-7e1b-401c-a392-584eaa2f28a3)
